### PR TITLE
feat(usb-uart): add FT232RL USB‑UART bridge and wire RX/TX to MCU

### DIFF
--- a/HW.kicad_prl
+++ b/HW.kicad_prl
@@ -1,7 +1,7 @@
 {
   "board": {
     "active_layer": 0,
-    "active_layer_preset": "",
+    "active_layer_preset": "All Layers",
     "auto_track_width": true,
     "hidden_netclasses": [],
     "hidden_nets": [],
@@ -62,9 +62,42 @@
     "version": 5
   },
   "net_inspector_panel": {
-    "col_hidden": [],
-    "col_order": [],
-    "col_widths": [],
+    "col_hidden": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ],
+    "col_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "col_widths": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
     "custom_group_rules": [],
     "expanded_rows": [],
     "filter_by_net_name": true,
@@ -75,7 +108,7 @@
     "show_unconnected_nets": false,
     "show_zero_pad_nets": false,
     "sort_ascending": true,
-    "sorting_column": -1
+    "sorting_column": 0
   },
   "open_jobsets": [],
   "project": {

--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -596,6 +596,14 @@
       "version": 1
     },
     "net_format_name": "",
+    "ngspice": {
+      "fix_include_paths": true,
+      "meta": {
+        "version": 0
+      },
+      "model_mode": 4,
+      "workbook_filename": ""
+    },
     "page_layout_descr_file": "",
     "plot_directory": "",
     "space_save_all_events": true,

--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -2,12 +2,213 @@
   "board": {
     "3dviewports": [],
     "design_settings": {
-      "defaults": {},
+      "defaults": {
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.05,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": true,
+          "text_position": 0,
+          "units_format": 0
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.1,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 0.8,
+          "height": 1.27,
+          "width": 2.54
+        },
+        "silk_line_width": 0.1,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.1,
+        "silk_text_upright": false,
+        "zones": {
+          "min_clearance": 0.5
+        }
+      },
       "diff_pair_dimensions": [],
       "drc_exclusions": [],
-      "rules": {},
+      "meta": {
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "creepage": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "ignore",
+        "hole_clearance": "error",
+        "hole_to_hole": "warning",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
+        "npth_inside_courtyard": "ignore",
+        "padstack": "warning",
+        "pth_inside_courtyard": "ignore",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "warning",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "error",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_on_edge_cuts": "error",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_angle": "error",
+        "track_dangling": "warning",
+        "track_segment_length": "error",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.0,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.5,
+        "min_groove_width": 0.0,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.0,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpthpad": true,
+          "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
+          "td_ontrackend": false,
+          "td_onvia": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
       "track_widths": [],
-      "via_dimensions": []
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [],
+      "zones_allow_external_fillets": false
     },
     "ipc2581": {
       "dist": "",
@@ -423,6 +624,10 @@
     [
       "360b299b-84d8-4d26-8110-4c6e53cc9fa4",
       "Power Tree"
+    ],
+    [
+      "b4895c98-2d65-46cb-a7d2-9672cea4def2",
+      "USB UART"
     ]
   ],
   "text_variables": {}

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(lib_symbols)
 	(bus_alias "BUS"
-		(members "VCC " "VCCA" "UART_TXD" "UART_RXD" "USB_VCC")
+		(members "VCC " "VCCA" "UART_TXD" "UART_RXD" "USB_VCC" "RESET")
 	)
 	(bus_entry
 		(at 124.46 67.31)
@@ -63,6 +63,15 @@
 		(uuid "5ce23706-9df5-4a7b-8265-40845c4d85c3")
 	)
 	(bus_entry
+		(at 147.32 113.03)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "64f0d274-9f84-4f28-9bb4-7dd5f2085585")
+	)
+	(bus_entry
 		(at 147.32 67.31)
 		(size 2.54 -2.54)
 		(stroke
@@ -88,6 +97,15 @@
 			(type default)
 		)
 		(uuid "92884432-44eb-4f8d-8314-f71d82b08582")
+	)
+	(bus_entry
+		(at 147.32 78.74)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8a52deb-b9f3-4dce-a96d-90efc6da25a5")
 	)
 	(bus_entry
 		(at 124.46 71.12)
@@ -156,6 +174,16 @@
 			(type default)
 		)
 		(uuid "31f13dfd-2b35-4185-8562-fd362a46af4f")
+	)
+	(bus
+		(pts
+			(xy 147.32 78.74) (xy 147.32 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d065abe-a774-45d7-baf7-28faccaa8832")
 	)
 	(wire
 		(pts
@@ -259,6 +287,26 @@
 	)
 	(bus
 		(pts
+			(xy 147.32 113.03) (xy 147.32 128.27)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "87f81104-e964-4015-9dc2-774129825d0f")
+	)
+	(wire
+		(pts
+			(xy 149.86 76.2) (xy 160.02 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a1418d7-0ba3-4af3-9207-8dc2cb9206c5")
+	)
+	(bus
+		(pts
 			(xy 124.46 67.31) (xy 124.46 63.5)
 		)
 		(stroke
@@ -299,6 +347,16 @@
 	)
 	(wire
 		(pts
+			(xy 149.86 115.57) (xy 161.29 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c5289e4b-a1e2-4d75-a19f-18c011b0d8d4")
+	)
+	(wire
+		(pts
 			(xy 149.86 68.58) (xy 160.02 68.58)
 		)
 		(stroke
@@ -329,7 +387,7 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 74.93) (xy 147.32 93.98)
+			(xy 147.32 74.93) (xy 147.32 78.74)
 		)
 		(stroke
 			(width 0)
@@ -349,7 +407,7 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 107.95) (xy 147.32 128.27)
+			(xy 147.32 107.95) (xy 147.32 113.03)
 		)
 		(stroke
 			(width 0)
@@ -367,6 +425,16 @@
 		)
 		(uuid "06a0e1f0-4df2-435c-86e0-e3c63aec5e29")
 	)
+	(label "RESET"
+		(at 160.02 76.2 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "0f1d3858-191c-4894-9eab-8d6851bb4f40")
+	)
 	(label "VCC "
 		(at 113.03 60.96 0)
 		(effects
@@ -376,6 +444,16 @@
 			(justify left bottom)
 		)
 		(uuid "10eedda6-d548-42f3-8fd2-047ac8260ff8")
+	)
+	(label "RESET"
+		(at 161.29 115.57 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "1fdb346e-9e93-4d20-8456-1c0e1e99e2f2")
 	)
 	(label "UART_TXD"
 		(at 160.02 72.39 180)
@@ -665,6 +743,16 @@
 				(justify left)
 			)
 		)
+		(pin "RESET" input
+			(at 161.29 115.57 180)
+			(uuid "fe822fd3-8af3-459a-9361-ddcccf94c05d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4"
@@ -740,6 +828,16 @@
 		(pin "USART1_RX" input
 			(at 160.02 72.39 180)
 			(uuid "adecbd38-3841-4fa6-ab6c-21ea6721c5aa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RESET" output
+			(at 160.02 76.2 180)
+			(uuid "41ff4177-18ab-44ec-beee-4c6138f15007")
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -27,6 +27,15 @@
 		(uuid "2a321a8e-f506-4f1c-8b7e-8d32dde068d1")
 	)
 	(bus_entry
+		(at 124.46 71.12)
+		(size -2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2c225b3d-6333-4d55-8965-f7c54c2379a3")
+	)
+	(bus_entry
 		(at 124.46 63.5)
 		(size -2.54 -2.54)
 		(stroke
@@ -108,15 +117,6 @@
 		(uuid "b8a52deb-b9f3-4dce-a96d-90efc6da25a5")
 	)
 	(bus_entry
-		(at 124.46 71.12)
-		(size -2.54 -2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "bb4ccd33-d228-4c08-a943-c2972055dc32")
-	)
-	(bus_entry
 		(at 147.32 93.98)
 		(size 2.54 2.54)
 		(stroke
@@ -165,6 +165,16 @@
 		)
 		(uuid "2729086d-d5c3-435f-a177-23330d7c22ac")
 	)
+	(bus
+		(pts
+			(xy 124.46 71.12) (xy 124.46 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2f37f946-ca5f-4918-9559-71cc88b68634")
+	)
 	(wire
 		(pts
 			(xy 149.86 100.33) (xy 161.29 100.33)
@@ -185,19 +195,9 @@
 		)
 		(uuid "3d065abe-a774-45d7-baf7-28faccaa8832")
 	)
-	(wire
-		(pts
-			(xy 121.92 68.58) (xy 113.03 68.58)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "444649af-83bc-45db-9fa1-c074e634a92b")
-	)
 	(bus
 		(pts
-			(xy 124.46 71.12) (xy 124.46 67.31)
+			(xy 124.46 67.31) (xy 124.46 71.12)
 		)
 		(stroke
 			(width 0)
@@ -234,6 +234,16 @@
 			(type default)
 		)
 		(uuid "53abe7c9-26f7-471b-8b30-0ec648e089e5")
+	)
+	(wire
+		(pts
+			(xy 121.92 68.58) (xy 113.03 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58f23c5f-9fde-4b27-9556-686c77b0e3d3")
 	)
 	(wire
 		(pts
@@ -274,16 +284,6 @@
 			(type default)
 		)
 		(uuid "66696df8-2938-4935-be40-7099ad52ffb8")
-	)
-	(bus
-		(pts
-			(xy 124.46 127) (xy 124.46 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7bb31373-ebf7-4cbe-8684-8f590eac7f6f")
 	)
 	(bus
 		(pts
@@ -485,6 +485,16 @@
 		)
 		(uuid "3478ce2b-77ab-43b1-b4d9-55df0e02803d")
 	)
+	(label "USB_VCC"
+		(at 113.03 68.58 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4d5e0253-59d0-4bd5-a052-fcc12b8315f8")
+	)
 	(label "UART_RXD"
 		(at 160.02 68.58 180)
 		(effects
@@ -524,16 +534,6 @@
 			(justify left bottom)
 		)
 		(uuid "b4a36359-5148-4be6-a07a-dd801a361790")
-	)
-	(label "USB_VCC"
-		(at 113.03 68.58 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "ecc0faa9-d431-4c65-a418-b0c7d64dfe74")
 	)
 	(label "UART_TXD"
 		(at 161.29 105.41 180)
@@ -651,9 +651,9 @@
 				(justify right)
 			)
 		)
-		(pin "USB_VCC" output
+		(pin "USB_VCC" input
 			(at 113.03 68.58 0)
-			(uuid "54ecc873-a1f5-4347-9fe1-92926cec1428")
+			(uuid "445c9892-806d-4ecb-8773-efaf9f058e98")
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -6,7 +6,25 @@
 	(paper "A4")
 	(lib_symbols)
 	(bus_alias "BUS"
-		(members "VCC " "VCCA" "UART_TXD" "UART_RXD" "USB_VCC" "RESET")
+		(members "VCC " "VCCA" "USB_UART_TXD" "USB_UART_RXD" "USB_VCC" "RESET")
+	)
+	(bus_entry
+		(at 147.32 107.95)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "085e1bdd-5174-4a04-9fc0-d4183dd15703")
+	)
+	(bus_entry
+		(at 147.32 71.12)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "147a43b3-f68d-41ef-9d2f-837ee20f0870")
 	)
 	(bus_entry
 		(at 124.46 67.31)
@@ -16,15 +34,6 @@
 			(type default)
 		)
 		(uuid "2738f141-1645-4ad5-a477-fd9257e768f9")
-	)
-	(bus_entry
-		(at 147.32 74.93)
-		(size 2.54 -2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2a321a8e-f506-4f1c-8b7e-8d32dde068d1")
 	)
 	(bus_entry
 		(at 124.46 71.12)
@@ -43,15 +52,6 @@
 			(type default)
 		)
 		(uuid "3bfede51-80d7-4e55-939c-84b0b23433ab")
-	)
-	(bus_entry
-		(at 147.32 107.95)
-		(size 2.54 2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "46767e73-bdcc-4040-a296-a2579c23a17b")
 	)
 	(bus_entry
 		(at 147.32 97.79)
@@ -90,22 +90,13 @@
 		(uuid "69263ba3-b30b-4b16-9cbb-722e6bf19a15")
 	)
 	(bus_entry
-		(at 147.32 71.12)
-		(size 2.54 -2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "71090b36-fc0e-467f-be09-081a0bc58a53")
-	)
-	(bus_entry
 		(at 147.32 102.87)
 		(size 2.54 2.54)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "92884432-44eb-4f8d-8314-f71d82b08582")
+		(uuid "aa4fef23-c0c9-4e60-adaf-a934056480f9")
 	)
 	(bus_entry
 		(at 147.32 78.74)
@@ -125,15 +116,14 @@
 		)
 		(uuid "ca5cc7b8-0e47-4884-8095-582164dfd7f3")
 	)
-	(bus
-		(pts
-			(xy 147.32 67.31) (xy 147.32 71.12)
-		)
+	(bus_entry
+		(at 147.32 74.93)
+		(size 2.54 -2.54)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "00c7b0ad-a963-422e-bbab-4991f6f935b6")
+		(uuid "d05e7e49-b312-44a3-8748-061042280b44")
 	)
 	(bus
 		(pts
@@ -147,13 +137,23 @@
 	)
 	(wire
 		(pts
-			(xy 121.92 64.77) (xy 113.03 64.77)
+			(xy 121.92 64.77) (xy 106.68 64.77)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "1141cd82-f07b-4dd1-b927-dc4fa73f2b82")
+	)
+	(wire
+		(pts
+			(xy 149.86 110.49) (xy 168.91 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1e30797f-52c6-4378-8ba5-47bc3d413b56")
 	)
 	(bus
 		(pts
@@ -177,7 +177,7 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 100.33) (xy 161.29 100.33)
+			(xy 149.86 100.33) (xy 168.91 100.33)
 		)
 		(stroke
 			(width 0)
@@ -207,7 +207,7 @@
 	)
 	(wire
 		(pts
-			(xy 121.92 60.96) (xy 113.03 60.96)
+			(xy 121.92 60.96) (xy 106.68 60.96)
 		)
 		(stroke
 			(width 0)
@@ -227,7 +227,7 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 60.96) (xy 160.02 60.96)
+			(xy 149.86 60.96) (xy 167.64 60.96)
 		)
 		(stroke
 			(width 0)
@@ -235,9 +235,19 @@
 		)
 		(uuid "53abe7c9-26f7-471b-8b30-0ec648e089e5")
 	)
+	(bus
+		(pts
+			(xy 147.32 102.87) (xy 147.32 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58ec6037-cb34-4046-ad52-0f073cf98ed7")
+	)
 	(wire
 		(pts
-			(xy 121.92 68.58) (xy 113.03 68.58)
+			(xy 121.92 68.58) (xy 106.68 68.58)
 		)
 		(stroke
 			(width 0)
@@ -245,15 +255,15 @@
 		)
 		(uuid "58f23c5f-9fde-4b27-9556-686c77b0e3d3")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 149.86 72.39) (xy 160.02 72.39)
+			(xy 147.32 74.93) (xy 147.32 78.74)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "5e719543-36f4-4bae-88c2-abdaaad6d8f9")
+		(uuid "5f10f8aa-f72b-4ebe-bd7e-2f0c9e4656dd")
 	)
 	(bus
 		(pts
@@ -265,19 +275,9 @@
 		)
 		(uuid "5f33a242-6c1a-4d9e-bf0e-b0ffdd784e69")
 	)
-	(bus
-		(pts
-			(xy 147.32 71.12) (xy 147.32 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "648ccb8f-1ed8-4024-938e-6c98273fcc85")
-	)
 	(wire
 		(pts
-			(xy 149.86 64.77) (xy 160.02 64.77)
+			(xy 149.86 64.77) (xy 167.64 64.77)
 		)
 		(stroke
 			(width 0)
@@ -287,7 +287,17 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 113.03) (xy 147.32 128.27)
+			(xy 147.32 71.12) (xy 147.32 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d5515da-a7a4-4e97-8de9-9e28f61cc35a")
+	)
+	(bus
+		(pts
+			(xy 147.32 113.03) (xy 147.32 127)
 		)
 		(stroke
 			(width 0)
@@ -297,7 +307,17 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 76.2) (xy 160.02 76.2)
+			(xy 149.86 68.58) (xy 167.64 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91dc8fb1-1ae2-429d-b7d7-d506757257f2")
+	)
+	(wire
+		(pts
+			(xy 149.86 76.2) (xy 167.64 76.2)
 		)
 		(stroke
 			(width 0)
@@ -317,7 +337,7 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 96.52) (xy 161.29 96.52)
+			(xy 149.86 96.52) (xy 168.91 96.52)
 		)
 		(stroke
 			(width 0)
@@ -335,19 +355,9 @@
 		)
 		(uuid "b5696688-85c1-4e98-9bf9-465097ac68e4")
 	)
-	(bus
-		(pts
-			(xy 147.32 102.87) (xy 147.32 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b903178a-4183-4c91-99e0-e5fbbeb58515")
-	)
 	(wire
 		(pts
-			(xy 149.86 115.57) (xy 161.29 115.57)
+			(xy 149.86 115.57) (xy 168.91 115.57)
 		)
 		(stroke
 			(width 0)
@@ -357,43 +367,33 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 68.58) (xy 160.02 68.58)
+			(xy 149.86 72.39) (xy 167.64 72.39)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c93a36a8-8450-42de-bf36-4693abc571a4")
-	)
-	(wire
-		(pts
-			(xy 149.86 105.41) (xy 161.29 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "cd1d2537-e45a-4738-ab83-a6e92c78a2d4")
-	)
-	(wire
-		(pts
-			(xy 149.86 110.49) (xy 161.29 110.49)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e73d78c8-7f10-44c8-b131-8ad3530a5fea")
+		(uuid "d6b43db9-23a2-4396-8fb8-decf92c5e69a")
 	)
 	(bus
 		(pts
-			(xy 147.32 74.93) (xy 147.32 78.74)
+			(xy 147.32 67.31) (xy 147.32 71.12)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "ecbf442e-4b4b-4559-8c70-513aaf6f2367")
+	)
+	(bus
+		(pts
+			(xy 147.32 107.95) (xy 147.32 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee14414b-2718-4837-8a79-dec53295d753")
 	)
 	(bus
 		(pts
@@ -405,28 +405,18 @@
 		)
 		(uuid "ef9c4b64-bb14-4b9e-a518-cebb359f13fc")
 	)
-	(bus
+	(wire
 		(pts
-			(xy 147.32 107.95) (xy 147.32 113.03)
+			(xy 149.86 105.41) (xy 168.91 105.41)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f034d32a-1490-4915-b13a-f6167f54a09a")
-	)
-	(label "UART_RXD"
-		(at 161.29 110.49 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "06a0e1f0-4df2-435c-86e0-e3c63aec5e29")
+		(uuid "f0e6b375-135c-4da3-b6dd-974e8e8b42af")
 	)
 	(label "RESET"
-		(at 160.02 76.2 180)
+		(at 167.64 76.2 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -436,7 +426,7 @@
 		(uuid "0f1d3858-191c-4894-9eab-8d6851bb4f40")
 	)
 	(label "VCC "
-		(at 113.03 60.96 0)
+		(at 106.68 60.96 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -445,8 +435,28 @@
 		)
 		(uuid "10eedda6-d548-42f3-8fd2-047ac8260ff8")
 	)
+	(label "USB_UART_RXD"
+		(at 168.91 110.49 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "1345effc-6614-4e81-b45f-154631894cc6")
+	)
+	(label "USB_UART_TXD"
+		(at 168.91 105.41 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "1901be1f-6881-4b50-bfb2-285d0923c80a")
+	)
 	(label "RESET"
-		(at 161.29 115.57 180)
+		(at 168.91 115.57 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -455,18 +465,8 @@
 		)
 		(uuid "1fdb346e-9e93-4d20-8456-1c0e1e99e2f2")
 	)
-	(label "UART_TXD"
-		(at 160.02 72.39 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "288a77ce-b1f2-4ea0-9bd2-8eb367f58318")
-	)
 	(label "USB_VCC"
-		(at 161.29 96.52 180)
+		(at 168.91 96.52 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -486,7 +486,7 @@
 		(uuid "3478ce2b-77ab-43b1-b4d9-55df0e02803d")
 	)
 	(label "USB_VCC"
-		(at 113.03 68.58 0)
+		(at 106.68 68.58 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -495,18 +495,18 @@
 		)
 		(uuid "4d5e0253-59d0-4bd5-a052-fcc12b8315f8")
 	)
-	(label "UART_RXD"
-		(at 160.02 68.58 180)
+	(label "USB_UART_RXD"
+		(at 167.64 68.58 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify right bottom)
 		)
-		(uuid "66f0e338-4c75-48b8-a194-8c638ee167b6")
+		(uuid "8d62d30e-a695-451f-ae6f-34b55d38ac20")
 	)
 	(label "VCC "
-		(at 160.02 60.96 180)
+		(at 167.64 60.96 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -516,7 +516,7 @@
 		(uuid "9be7556e-95f0-449b-90fd-2d444ce9e89d")
 	)
 	(label "VCC "
-		(at 161.29 100.33 180)
+		(at 168.91 100.33 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -526,7 +526,7 @@
 		(uuid "a62e59b2-d0c1-424b-93c8-3b1e8d46c582")
 	)
 	(label "VCCA"
-		(at 113.03 64.77 0)
+		(at 106.68 64.77 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -535,18 +535,18 @@
 		)
 		(uuid "b4a36359-5148-4be6-a07a-dd801a361790")
 	)
-	(label "UART_TXD"
-		(at 161.29 105.41 180)
+	(label "USB_UART_TXD"
+		(at 167.64 72.39 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify right bottom)
 		)
-		(uuid "f4184472-4e53-47a8-a434-560161f10e7c")
+		(uuid "f02c8ff7-47fe-46de-a526-919a2b22303f")
 	)
 	(label "VCCA"
-		(at 160.02 64.77 180)
+		(at 167.64 64.77 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -556,7 +556,7 @@
 		(uuid "fdc0fe38-817f-40bf-b312-cbd809ce683a")
 	)
 	(sheet
-		(at 78.74 93.98)
+		(at 72.39 93.98)
 		(size 34.29 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -572,7 +572,7 @@
 		)
 		(uuid "2dab47df-4ca4-4373-b48e-0efc8c61f605")
 		(property "Sheetname" "LoRA Module"
-			(at 78.74 93.2684 0)
+			(at 72.39 93.2684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -581,7 +581,7 @@
 			)
 		)
 		(property "Sheetfile" "lora_module.kicad_sch"
-			(at 78.74 126.3146 0)
+			(at 72.39 126.3146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -598,7 +598,7 @@
 		)
 	)
 	(sheet
-		(at 78.74 55.88)
+		(at 72.39 55.88)
 		(size 34.29 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -614,7 +614,7 @@
 		)
 		(uuid "360b299b-84d8-4d26-8110-4c6e53cc9fa4")
 		(property "Sheetname" "Power Tree"
-			(at 78.74 55.1684 0)
+			(at 72.39 55.1684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -623,7 +623,7 @@
 			)
 		)
 		(property "Sheetfile" "power_tree.kicad_sch"
-			(at 78.74 88.2146 0)
+			(at 72.39 88.2146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -632,7 +632,7 @@
 			)
 		)
 		(pin "3V3_VCC" passive
-			(at 113.03 60.96 0)
+			(at 106.68 60.96 0)
 			(uuid "0cec6859-1259-458d-8f6e-e26c4dc22c80")
 			(effects
 				(font
@@ -642,7 +642,7 @@
 			)
 		)
 		(pin "3V3_VCCA" passive
-			(at 113.03 64.77 0)
+			(at 106.68 64.77 0)
 			(uuid "9cbd90bc-64b5-486e-b264-1509175741c7")
 			(effects
 				(font
@@ -652,7 +652,7 @@
 			)
 		)
 		(pin "USB_VCC" passive
-			(at 113.03 68.58 0)
+			(at 106.68 68.58 0)
 			(uuid "c5c74bf2-8f76-4298-993d-76c49a3498ef")
 			(effects
 				(font
@@ -670,7 +670,7 @@
 		)
 	)
 	(sheet
-		(at 161.29 93.98)
+		(at 168.91 93.98)
 		(size 33.02 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -686,7 +686,7 @@
 		)
 		(uuid "b4895c98-2d65-46cb-a7d2-9672cea4def2")
 		(property "Sheetname" "USB UART"
-			(at 161.29 93.2684 0)
+			(at 168.91 93.2684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -695,7 +695,7 @@
 			)
 		)
 		(property "Sheetfile" "USB_UART.kicad_sch"
-			(at 161.29 126.3146 0)
+			(at 168.91 126.3146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -704,7 +704,7 @@
 			)
 		)
 		(pin "UART_RXD" input
-			(at 161.29 110.49 180)
+			(at 168.91 110.49 180)
 			(uuid "3563ee22-b6ab-4804-9cf4-8bf0529be6c3")
 			(effects
 				(font
@@ -714,7 +714,7 @@
 			)
 		)
 		(pin "UART_TXD" output
-			(at 161.29 105.41 180)
+			(at 168.91 105.41 180)
 			(uuid "9f13a2cc-3a2d-44b4-86e8-06f1620e8fd1")
 			(effects
 				(font
@@ -724,7 +724,7 @@
 			)
 		)
 		(pin "RESET" input
-			(at 161.29 115.57 180)
+			(at 168.91 115.57 180)
 			(uuid "fe822fd3-8af3-459a-9361-ddcccf94c05d")
 			(effects
 				(font
@@ -734,7 +734,7 @@
 			)
 		)
 		(pin "USB_VCC" passive
-			(at 161.29 96.52 180)
+			(at 168.91 96.52 180)
 			(uuid "d3a3ed0d-5c51-44c7-8b13-99fdd882e27b")
 			(effects
 				(font
@@ -744,7 +744,7 @@
 			)
 		)
 		(pin "3V3_VCC" passive
-			(at 161.29 100.33 180)
+			(at 168.91 100.33 180)
 			(uuid "74c219fd-1bd1-4453-8440-3a7fed1851e7")
 			(effects
 				(font
@@ -762,7 +762,7 @@
 		)
 	)
 	(sheet
-		(at 160.02 55.88)
+		(at 167.64 55.88)
 		(size 34.29 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -778,7 +778,7 @@
 		)
 		(uuid "edb1e4c3-83a3-4443-aa4b-0e758d3bea47")
 		(property "Sheetname" "MCU"
-			(at 160.02 55.1684 0)
+			(at 167.64 55.1684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -787,7 +787,7 @@
 			)
 		)
 		(property "Sheetfile" "mcu.kicad_sch"
-			(at 160.02 88.2146 0)
+			(at 167.64 88.2146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -796,7 +796,7 @@
 			)
 		)
 		(pin "USART1_TX" output
-			(at 160.02 68.58 180)
+			(at 167.64 68.58 180)
 			(uuid "92b58b44-b604-4668-a482-763cd062249d")
 			(effects
 				(font
@@ -806,7 +806,7 @@
 			)
 		)
 		(pin "USART1_RX" input
-			(at 160.02 72.39 180)
+			(at 167.64 72.39 180)
 			(uuid "adecbd38-3841-4fa6-ab6c-21ea6721c5aa")
 			(effects
 				(font
@@ -816,7 +816,7 @@
 			)
 		)
 		(pin "RESET" output
-			(at 160.02 76.2 180)
+			(at 167.64 76.2 180)
 			(uuid "41ff4177-18ab-44ec-beee-4c6138f15007")
 			(effects
 				(font
@@ -826,7 +826,7 @@
 			)
 		)
 		(pin "VCC" passive
-			(at 160.02 60.96 180)
+			(at 167.64 60.96 180)
 			(uuid "6d511e74-9b46-4639-8a80-5b1293097b1e")
 			(effects
 				(font
@@ -836,7 +836,7 @@
 			)
 		)
 		(pin "VCCCA" passive
-			(at 160.02 64.77 180)
+			(at 167.64 64.77 180)
 			(uuid "048c4acd-d489-4db0-8b95-31ace6b9a6ce")
 			(effects
 				(font

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -27,15 +27,6 @@
 		(uuid "2c225b3d-6333-4d55-8965-f7c54c2379a3")
 	)
 	(bus_entry
-		(at 147.32 102.87)
-		(size 2.54 2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "35bbcfec-8a78-44ed-addd-48232a7a2dcd")
-	)
-	(bus_entry
 		(at 124.46 63.5)
 		(size -2.54 -2.54)
 		(stroke
@@ -43,6 +34,24 @@
 			(type default)
 		)
 		(uuid "3bfede51-80d7-4e55-939c-84b0b23433ab")
+	)
+	(bus_entry
+		(at 147.32 71.12)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d9da864-ac61-4fde-a286-a21179b09f25")
+	)
+	(bus_entry
+		(at 147.32 102.87)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e2b8726-fe7e-46a6-9e18-9c050a99f1fc")
 	)
 	(bus_entry
 		(at 147.32 97.79)
@@ -87,7 +96,16 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7f128727-ffbf-487b-a72a-9e7c39b6078f")
+		(uuid "988a54f0-368d-40fe-9a6c-a42f6fb3d9bb")
+	)
+	(bus_entry
+		(at 147.32 107.95)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "98a51ae3-6d81-447b-8558-3ae3d17df93d")
 	)
 	(bus_entry
 		(at 147.32 78.74)
@@ -107,23 +125,15 @@
 		)
 		(uuid "ca5cc7b8-0e47-4884-8095-582164dfd7f3")
 	)
-	(bus_entry
-		(at 147.32 107.95)
-		(size 2.54 2.54)
+	(wire
+		(pts
+			(xy 149.86 72.39) (xy 167.64 72.39)
+		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d9dd92d6-e4d3-44fe-b225-35a69178aa19")
-	)
-	(bus_entry
-		(at 147.32 71.12)
-		(size 2.54 -2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "de24e966-8a9c-412b-b35a-eaa4e0e05882")
+		(uuid "10abb794-1201-49bf-b248-b653cfffc9f1")
 	)
 	(wire
 		(pts
@@ -167,6 +177,16 @@
 	)
 	(bus
 		(pts
+			(xy 147.32 71.12) (xy 147.32 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ae3153d-88dc-4bc5-ae49-51375c559432")
+	)
+	(bus
+		(pts
 			(xy 147.32 78.74) (xy 147.32 93.98)
 		)
 		(stroke
@@ -174,6 +194,16 @@
 			(type default)
 		)
 		(uuid "3d065abe-a774-45d7-baf7-28faccaa8832")
+	)
+	(wire
+		(pts
+			(xy 149.86 105.41) (xy 168.91 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "47ab4348-78b1-441b-8211-db795ec5a737")
 	)
 	(bus
 		(pts
@@ -184,16 +214,6 @@
 			(type default)
 		)
 		(uuid "49695ebb-cc86-42b1-b5f7-e0c2d6d7a34f")
-	)
-	(wire
-		(pts
-			(xy 149.86 110.49) (xy 168.91 110.49)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "49f43578-711a-4ddc-b5da-8883c464950a")
 	)
 	(wire
 		(pts
@@ -224,16 +244,6 @@
 			(type default)
 		)
 		(uuid "53abe7c9-26f7-471b-8b30-0ec648e089e5")
-	)
-	(wire
-		(pts
-			(xy 149.86 72.39) (xy 167.64 72.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "54c76cf2-c151-4077-9dd5-d5115c70341f")
 	)
 	(wire
 		(pts
@@ -275,15 +285,15 @@
 		)
 		(uuid "7565557f-38a3-4868-b8f7-2abaf6843beb")
 	)
-	(bus
+	(wire
 		(pts
-			(xy 147.32 97.79) (xy 147.32 102.87)
+			(xy 149.86 110.49) (xy 168.91 110.49)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "87f81104-e964-4015-9dc2-774129825d0f")
+		(uuid "8bc8abcf-9982-4878-b81e-436206fcadd6")
 	)
 	(wire
 		(pts
@@ -305,16 +315,6 @@
 		)
 		(uuid "a0a2ea45-28b0-4c9f-84f3-10624f6320d7")
 	)
-	(bus
-		(pts
-			(xy 147.32 107.95) (xy 147.32 113.03)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a27a180f-e506-4098-9730-33b30e41b6ef")
-	)
 	(wire
 		(pts
 			(xy 149.86 68.58) (xy 167.64 68.58)
@@ -323,7 +323,17 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a8a3b8d6-2413-4fbc-bff2-cce35992476c")
+		(uuid "a0d5537b-596c-4b6b-abf1-cf746236d9b0")
+	)
+	(bus
+		(pts
+			(xy 147.32 97.79) (xy 147.32 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a27a180f-e506-4098-9730-33b30e41b6ef")
 	)
 	(wire
 		(pts
@@ -345,6 +355,16 @@
 		)
 		(uuid "b5696688-85c1-4e98-9bf9-465097ac68e4")
 	)
+	(bus
+		(pts
+			(xy 147.32 74.93) (xy 147.32 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf9847d8-f02a-4c1d-94e6-49128744a05c")
+	)
 	(wire
 		(pts
 			(xy 149.86 115.57) (xy 168.91 115.57)
@@ -357,33 +377,23 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 74.93) (xy 147.32 78.74)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ca688300-cfc6-4c0e-865a-af09e6ed0a98")
-	)
-	(bus
-		(pts
-			(xy 147.32 71.12) (xy 147.32 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e22a7c9d-7947-46ae-85b6-ca851acbf771")
-	)
-	(bus
-		(pts
 			(xy 147.32 102.87) (xy 147.32 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e9197cfb-26e1-4ab0-b05b-cc1e90d8f4de")
+		(uuid "e5c7ef48-b5b1-4432-bf1f-96efe669507c")
+	)
+	(bus
+		(pts
+			(xy 147.32 107.95) (xy 147.32 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e706ebce-a6a7-498d-a172-df53222f1ea1")
 	)
 	(bus
 		(pts
@@ -404,26 +414,6 @@
 			(type default)
 		)
 		(uuid "ef9c4b64-bb14-4b9e-a518-cebb359f13fc")
-	)
-	(wire
-		(pts
-			(xy 149.86 105.41) (xy 168.91 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f837f48d-f0ba-4092-a27a-811598a5a6bf")
-	)
-	(label "USB_UART_RX"
-		(at 168.91 110.49 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "0a1c61f5-47f0-4904-9f24-2802ef557589")
 	)
 	(label "RESET"
 		(at 167.64 76.2 180)
@@ -485,7 +475,7 @@
 		)
 		(uuid "4d5e0253-59d0-4bd5-a052-fcc12b8315f8")
 	)
-	(label "USB_UART_TX"
+	(label "USB_UART_RX"
 		(at 168.91 105.41 180)
 		(effects
 			(font
@@ -493,17 +483,7 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "608eac73-6959-4342-9a2f-ad8f36b4a1d5")
-	)
-	(label "USB_UART_RX"
-		(at 167.64 68.58 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "982535db-5408-48e6-872a-64aa28834aa2")
+		(uuid "55c48477-93c8-4052-b067-628a5fbbdbf2")
 	)
 	(label "VCC "
 		(at 167.64 60.96 180)
@@ -536,6 +516,26 @@
 		(uuid "b4a36359-5148-4be6-a07a-dd801a361790")
 	)
 	(label "USB_UART_TX"
+		(at 167.64 68.58 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "bab11601-c9f1-44dd-aa4a-d20891ab8f1b")
+	)
+	(label "USB_UART_TX"
+		(at 168.91 110.49 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "db54bc25-02ff-469f-a16f-c2e669b26775")
+	)
+	(label "USB_UART_RX"
 		(at 167.64 72.39 180)
 		(effects
 			(font
@@ -543,7 +543,7 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "e2ac98d7-f821-4dd7-84a8-fce1f2e064e1")
+		(uuid "fd2cdcf5-8237-43a2-8158-2401072275cc")
 	)
 	(label "VCCA"
 		(at 167.64 64.77 180)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -6,25 +6,7 @@
 	(paper "A4")
 	(lib_symbols)
 	(bus_alias "BUS"
-		(members "VCC " "VCCA" "USB_UART_TXD" "USB_UART_RXD" "USB_VCC" "RESET")
-	)
-	(bus_entry
-		(at 147.32 107.95)
-		(size 2.54 2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "085e1bdd-5174-4a04-9fc0-d4183dd15703")
-	)
-	(bus_entry
-		(at 147.32 71.12)
-		(size 2.54 -2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "147a43b3-f68d-41ef-9d2f-837ee20f0870")
+		(members "VCC " "VCCA" "USB_UART_TX" "USB_UART_RX" "USB_VCC" "RESET")
 	)
 	(bus_entry
 		(at 124.46 67.31)
@@ -43,6 +25,15 @@
 			(type default)
 		)
 		(uuid "2c225b3d-6333-4d55-8965-f7c54c2379a3")
+	)
+	(bus_entry
+		(at 147.32 102.87)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35bbcfec-8a78-44ed-addd-48232a7a2dcd")
 	)
 	(bus_entry
 		(at 124.46 63.5)
@@ -90,13 +81,13 @@
 		(uuid "69263ba3-b30b-4b16-9cbb-722e6bf19a15")
 	)
 	(bus_entry
-		(at 147.32 102.87)
-		(size 2.54 2.54)
+		(at 147.32 74.93)
+		(size 2.54 -2.54)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "aa4fef23-c0c9-4e60-adaf-a934056480f9")
+		(uuid "7f128727-ffbf-487b-a72a-9e7c39b6078f")
 	)
 	(bus_entry
 		(at 147.32 78.74)
@@ -117,23 +108,22 @@
 		(uuid "ca5cc7b8-0e47-4884-8095-582164dfd7f3")
 	)
 	(bus_entry
-		(at 147.32 74.93)
+		(at 147.32 107.95)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d9dd92d6-e4d3-44fe-b225-35a69178aa19")
+	)
+	(bus_entry
+		(at 147.32 71.12)
 		(size 2.54 -2.54)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d05e7e49-b312-44a3-8748-061042280b44")
-	)
-	(bus
-		(pts
-			(xy 147.32 97.79) (xy 147.32 102.87)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0cd7215b-1862-4136-b7aa-c1dc57958fac")
+		(uuid "de24e966-8a9c-412b-b35a-eaa4e0e05882")
 	)
 	(wire
 		(pts
@@ -144,16 +134,6 @@
 			(type default)
 		)
 		(uuid "1141cd82-f07b-4dd1-b927-dc4fa73f2b82")
-	)
-	(wire
-		(pts
-			(xy 149.86 110.49) (xy 168.91 110.49)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "1e30797f-52c6-4378-8ba5-47bc3d413b56")
 	)
 	(bus
 		(pts
@@ -207,6 +187,16 @@
 	)
 	(wire
 		(pts
+			(xy 149.86 110.49) (xy 168.91 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "49f43578-711a-4ddc-b5da-8883c464950a")
+	)
+	(wire
+		(pts
 			(xy 121.92 60.96) (xy 106.68 60.96)
 		)
 		(stroke
@@ -235,15 +225,15 @@
 		)
 		(uuid "53abe7c9-26f7-471b-8b30-0ec648e089e5")
 	)
-	(bus
+	(wire
 		(pts
-			(xy 147.32 102.87) (xy 147.32 107.95)
+			(xy 149.86 72.39) (xy 167.64 72.39)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "58ec6037-cb34-4046-ad52-0f073cf98ed7")
+		(uuid "54c76cf2-c151-4077-9dd5-d5115c70341f")
 	)
 	(wire
 		(pts
@@ -254,16 +244,6 @@
 			(type default)
 		)
 		(uuid "58f23c5f-9fde-4b27-9556-686c77b0e3d3")
-	)
-	(bus
-		(pts
-			(xy 147.32 74.93) (xy 147.32 78.74)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5f10f8aa-f72b-4ebe-bd7e-2f0c9e4656dd")
 	)
 	(bus
 		(pts
@@ -287,33 +267,23 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 71.12) (xy 147.32 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7d5515da-a7a4-4e97-8de9-9e28f61cc35a")
-	)
-	(bus
-		(pts
 			(xy 147.32 113.03) (xy 147.32 127)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "87f81104-e964-4015-9dc2-774129825d0f")
+		(uuid "7565557f-38a3-4868-b8f7-2abaf6843beb")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 149.86 68.58) (xy 167.64 68.58)
+			(xy 147.32 97.79) (xy 147.32 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "91dc8fb1-1ae2-429d-b7d7-d506757257f2")
+		(uuid "87f81104-e964-4015-9dc2-774129825d0f")
 	)
 	(wire
 		(pts
@@ -334,6 +304,26 @@
 			(type default)
 		)
 		(uuid "a0a2ea45-28b0-4c9f-84f3-10624f6320d7")
+	)
+	(bus
+		(pts
+			(xy 147.32 107.95) (xy 147.32 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a27a180f-e506-4098-9730-33b30e41b6ef")
+	)
+	(wire
+		(pts
+			(xy 149.86 68.58) (xy 167.64 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8a3b8d6-2413-4fbc-bff2-cce35992476c")
 	)
 	(wire
 		(pts
@@ -365,15 +355,35 @@
 		)
 		(uuid "c5289e4b-a1e2-4d75-a19f-18c011b0d8d4")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 149.86 72.39) (xy 167.64 72.39)
+			(xy 147.32 74.93) (xy 147.32 78.74)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d6b43db9-23a2-4396-8fb8-decf92c5e69a")
+		(uuid "ca688300-cfc6-4c0e-865a-af09e6ed0a98")
+	)
+	(bus
+		(pts
+			(xy 147.32 71.12) (xy 147.32 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e22a7c9d-7947-46ae-85b6-ca851acbf771")
+	)
+	(bus
+		(pts
+			(xy 147.32 102.87) (xy 147.32 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e9197cfb-26e1-4ab0-b05b-cc1e90d8f4de")
 	)
 	(bus
 		(pts
@@ -384,16 +394,6 @@
 			(type default)
 		)
 		(uuid "ecbf442e-4b4b-4559-8c70-513aaf6f2367")
-	)
-	(bus
-		(pts
-			(xy 147.32 107.95) (xy 147.32 113.03)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ee14414b-2718-4837-8a79-dec53295d753")
 	)
 	(bus
 		(pts
@@ -413,7 +413,17 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f0e6b375-135c-4da3-b6dd-974e8e8b42af")
+		(uuid "f837f48d-f0ba-4092-a27a-811598a5a6bf")
+	)
+	(label "USB_UART_RX"
+		(at 168.91 110.49 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "0a1c61f5-47f0-4904-9f24-2802ef557589")
 	)
 	(label "RESET"
 		(at 167.64 76.2 180)
@@ -434,26 +444,6 @@
 			(justify left bottom)
 		)
 		(uuid "10eedda6-d548-42f3-8fd2-047ac8260ff8")
-	)
-	(label "USB_UART_RXD"
-		(at 168.91 110.49 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "1345effc-6614-4e81-b45f-154631894cc6")
-	)
-	(label "USB_UART_TXD"
-		(at 168.91 105.41 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "1901be1f-6881-4b50-bfb2-285d0923c80a")
 	)
 	(label "RESET"
 		(at 168.91 115.57 180)
@@ -495,7 +485,17 @@
 		)
 		(uuid "4d5e0253-59d0-4bd5-a052-fcc12b8315f8")
 	)
-	(label "USB_UART_RXD"
+	(label "USB_UART_TX"
+		(at 168.91 105.41 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "608eac73-6959-4342-9a2f-ad8f36b4a1d5")
+	)
+	(label "USB_UART_RX"
 		(at 167.64 68.58 180)
 		(effects
 			(font
@@ -503,7 +503,7 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "8d62d30e-a695-451f-ae6f-34b55d38ac20")
+		(uuid "982535db-5408-48e6-872a-64aa28834aa2")
 	)
 	(label "VCC "
 		(at 167.64 60.96 180)
@@ -535,7 +535,7 @@
 		)
 		(uuid "b4a36359-5148-4be6-a07a-dd801a361790")
 	)
-	(label "USB_UART_TXD"
+	(label "USB_UART_TX"
 		(at 167.64 72.39 180)
 		(effects
 			(font
@@ -543,7 +543,7 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "f02c8ff7-47fe-46de-a526-919a2b22303f")
+		(uuid "e2ac98d7-f821-4dd7-84a8-fce1f2e064e1")
 	)
 	(label "VCCA"
 		(at 167.64 64.77 180)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -5,215 +5,481 @@
 	(uuid "01550cd7-b424-469c-925b-c370f3609cd4")
 	(paper "A4")
 	(lib_symbols)
-	(junction
-		(at 146.05 60.96)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "3c3cdb30-3c67-43fa-9900-f6ded5d82ddb")
+	(bus_alias "BUS"
+		(members "VCC " "VCCA" "UART_TXD" "UART_RXD" "USB_VCC")
 	)
-	(wire
+	(bus_entry
+		(at 124.46 67.31)
+		(size -2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2738f141-1645-4ad5-a477-fd9257e768f9")
+	)
+	(bus_entry
+		(at 124.46 63.5)
+		(size -2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3bfede51-80d7-4e55-939c-84b0b23433ab")
+	)
+	(bus_entry
+		(at 147.32 97.79)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57b0a374-3e15-498a-9811-2721fcb60a04")
+	)
+	(bus_entry
+		(at 147.32 63.5)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ce23706-9df5-4a7b-8265-40845c4d85c3")
+	)
+	(bus_entry
+		(at 147.32 67.31)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69263ba3-b30b-4b16-9cbb-722e6bf19a15")
+	)
+	(bus_entry
+		(at 124.46 71.12)
+		(size -2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb4ccd33-d228-4c08-a943-c2972055dc32")
+	)
+	(bus_entry
+		(at 147.32 93.98)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca5cc7b8-0e47-4884-8095-582164dfd7f3")
+	)
+	(bus_entry
+		(at 147.32 101.6)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2281c38-e3be-4ec5-9179-f402e46fe6c6")
+	)
+	(bus_entry
+		(at 147.32 71.12)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e84bbbf9-4ab5-4ea6-921a-472c8bf717f4")
+	)
+	(bus_entry
+		(at 147.32 74.93)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f606cf46-c1e4-4e58-92fa-e0e356ad98ba")
+	)
+	(bus_entry
+		(at 147.32 105.41)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f88d79e2-019c-4b46-b9a4-deb04d416635")
+	)
+	(bus
 		(pts
-			(xy 118.11 60.96) (xy 146.05 60.96)
+			(xy 147.32 97.79) (xy 147.32 101.6)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "0641a97e-7748-44cd-be88-338a9ff6ab6f")
+		(uuid "0cd7215b-1862-4136-b7aa-c1dc57958fac")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 118.11 68.58) (xy 140.97 68.58)
+			(xy 147.32 71.12) (xy 147.32 74.93)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "08374c0f-6684-44e2-9371-427fe6af03ac")
+		(uuid "0f23a3a5-69fa-408b-8f66-63d36d021eb8")
 	)
 	(wire
 		(pts
-			(xy 194.31 107.95) (xy 203.2 107.95)
+			(xy 121.92 64.77) (xy 113.03 64.77)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "10200d5d-7cc6-4609-b53c-cc807d72f430")
+		(uuid "1141cd82-f07b-4dd1-b927-dc4fa73f2b82")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 199.39 102.87) (xy 194.31 102.87)
+			(xy 124.46 63.5) (xy 124.46 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1086583a-cc4e-4d2c-a364-b0f9ca4866e1")
+		(uuid "2729086d-d5c3-435f-a177-23330d7c22ac")
 	)
 	(wire
 		(pts
-			(xy 118.11 72.39) (xy 135.89 72.39)
+			(xy 149.86 72.39) (xy 160.02 72.39)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "16e478f6-9c14-4728-b311-9ddf0fd7b8bb")
+		(uuid "2c2895a6-407f-45be-a094-cfb8246eaea2")
 	)
 	(wire
 		(pts
-			(xy 135.89 113.03) (xy 161.29 113.03)
+			(xy 149.86 68.58) (xy 160.02 68.58)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1c1988cf-062f-407f-bf8b-f9b6c00a3eb8")
+		(uuid "2ec20c22-53ce-48cf-999d-4df84acdb8d8")
 	)
 	(wire
 		(pts
-			(xy 160.02 64.77) (xy 118.11 64.77)
+			(xy 149.86 100.33) (xy 161.29 100.33)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "205dcf13-1519-43eb-9c0b-714b4a222857")
+		(uuid "31f13dfd-2b35-4185-8562-fd362a46af4f")
 	)
 	(wire
 		(pts
-			(xy 135.89 72.39) (xy 135.89 113.03)
+			(xy 149.86 107.95) (xy 161.29 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "336f38f3-09eb-4b6a-95da-b2dbe4b75ac1")
+		(uuid "33581d2a-fb03-4f9c-84a5-dc06495d0a13")
 	)
 	(wire
 		(pts
-			(xy 130.81 76.2) (xy 130.81 118.11)
+			(xy 121.92 68.58) (xy 113.03 68.58)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "34f16098-1fec-4adb-b2dc-ac97c76c551b")
+		(uuid "444649af-83bc-45db-9fa1-c074e634a92b")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 194.31 60.96) (xy 203.2 60.96)
+			(xy 124.46 71.12) (xy 124.46 67.31)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "439a16b7-f968-484e-a2bc-fcf271807644")
+		(uuid "49695ebb-cc86-42b1-b5f7-e0c2d6d7a34f")
 	)
 	(wire
 		(pts
-			(xy 146.05 60.96) (xy 160.02 60.96)
+			(xy 121.92 60.96) (xy 113.03 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "52c8e71f-10c7-4e71-8766-4141f998d50a")
+		(uuid "4d15f9cc-e9f1-4fa9-a489-611b183b97d0")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 203.2 107.95) (xy 203.2 60.96)
+			(xy 147.32 57.15) (xy 147.32 63.5)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "703a083e-2119-4541-b1f1-68eb69555519")
+		(uuid "4fd90bd8-1639-4e42-a7ae-9557ace81744")
 	)
 	(wire
 		(pts
-			(xy 118.11 76.2) (xy 130.81 76.2)
+			(xy 149.86 60.96) (xy 160.02 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "7f1bf33c-de20-4e35-a7f3-bef6eba58ee4")
+		(uuid "53abe7c9-26f7-471b-8b30-0ec648e089e5")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 140.97 107.95) (xy 161.29 107.95)
+			(xy 124.46 57.15) (xy 147.32 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "82252ba9-dfd2-441f-b88e-d058abae3566")
+		(uuid "5f33a242-6c1a-4d9e-bf0e-b0ffdd784e69")
 	)
 	(wire
 		(pts
-			(xy 130.81 118.11) (xy 161.29 118.11)
+			(xy 149.86 64.77) (xy 160.02 64.77)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "9ba78704-d088-458c-b7e5-b018d7ba5de4")
+		(uuid "66696df8-2938-4935-be40-7099ad52ffb8")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 140.97 68.58) (xy 140.97 107.95)
+			(xy 124.46 127) (xy 124.46 71.12)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "9fbe4586-b4f6-4d38-81ca-037ac33413d2")
+		(uuid "7bb31373-ebf7-4cbe-8684-8f590eac7f6f")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 146.05 102.87) (xy 161.29 102.87)
+			(xy 147.32 105.41) (xy 147.32 128.27)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "abbd5a1e-f21c-45d2-a004-765a8e06498c")
+		(uuid "9d161b5c-ad7c-4dc6-93de-8a96b1a53483")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 146.05 60.96) (xy 146.05 102.87)
+			(xy 124.46 67.31) (xy 124.46 63.5)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "be540f7c-9553-442d-9d1d-f3e68a225b77")
+		(uuid "a0a2ea45-28b0-4c9f-84f3-10624f6320d7")
 	)
-	(wire
+	(bus
 		(pts
-			(xy 199.39 64.77) (xy 199.39 102.87)
+			(xy 147.32 101.6) (xy 147.32 105.41)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e2a72250-15d2-4ea8-92f5-23e9096cac2e")
+		(uuid "aad16e27-a931-4062-8bae-2bccf721c428")
 	)
 	(wire
 		(pts
-			(xy 194.31 64.77) (xy 199.39 64.77)
+			(xy 149.86 96.52) (xy 161.29 96.52)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f2f619f1-65b4-4b45-a7cd-bbb2279ab3d8")
+		(uuid "ab8f34ee-5f23-4998-8e79-e276cff4b3a7")
+	)
+	(bus
+		(pts
+			(xy 147.32 74.93) (xy 147.32 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad8f6822-5dc0-4559-abf3-ca47ddc2ceb9")
+	)
+	(wire
+		(pts
+			(xy 149.86 104.14) (xy 161.29 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b07349ef-7ce7-4d50-89c0-2c9db2fead25")
+	)
+	(bus
+		(pts
+			(xy 147.32 67.31) (xy 147.32 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b5696688-85c1-4e98-9bf9-465097ac68e4")
+	)
+	(bus
+		(pts
+			(xy 147.32 63.5) (xy 147.32 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d7843659-763c-4140-bd7d-564dea61ee21")
+	)
+	(bus
+		(pts
+			(xy 147.32 93.98) (xy 147.32 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef9c4b64-bb14-4b9e-a518-cebb359f13fc")
+	)
+	(label "UART_RXD"
+		(at 160.02 68.58 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "075699bf-9c3a-4420-9e62-e8785c0d28e2")
+	)
+	(label "UART_RXD"
+		(at 161.29 107.95 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "09ff394b-6ec1-4843-a9fd-17f1e71c3a00")
+	)
+	(label "VCC "
+		(at 113.03 60.96 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "10eedda6-d548-42f3-8fd2-047ac8260ff8")
+	)
+	(label "USB_VCC"
+		(at 161.29 96.52 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "325f723a-298d-41c3-82ca-366b3e796197")
+	)
+	(label "{BUS}"
+		(at 133.35 57.15 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "3478ce2b-77ab-43b1-b4d9-55df0e02803d")
+	)
+	(label "VCC "
+		(at 160.02 60.96 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "9be7556e-95f0-449b-90fd-2d444ce9e89d")
+	)
+	(label "UART_TXD"
+		(at 161.29 104.14 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "a19cdb85-dca3-459b-8e0f-5fa9f966cbc6")
+	)
+	(label "UART_TXD"
+		(at 160.02 72.39 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "a3368c74-6e84-422e-9bda-ae584f3a2b5e")
+	)
+	(label "VCC "
+		(at 161.29 100.33 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "a62e59b2-d0c1-424b-93c8-3b1e8d46c582")
+	)
+	(label "VCCA"
+		(at 113.03 64.77 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b4a36359-5148-4be6-a07a-dd801a361790")
+	)
+	(label "USB_VCC"
+		(at 113.03 68.58 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ecc0faa9-d431-4c65-a418-b0c7d64dfe74")
+	)
+	(label "VCCA"
+		(at 160.02 64.77 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "fdc0fe38-817f-40bf-b312-cbd809ce683a")
 	)
 	(sheet
-		(at 30.48 83.82)
-		(size 39.37 31.75)
+		(at 78.74 93.98)
+		(size 34.29 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
@@ -228,7 +494,7 @@
 		)
 		(uuid "2dab47df-4ca4-4373-b48e-0efc8c61f605")
 		(property "Sheetname" "LoRA Module"
-			(at 30.48 83.1084 0)
+			(at 78.74 93.2684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -237,7 +503,7 @@
 			)
 		)
 		(property "Sheetfile" "lora_module.kicad_sch"
-			(at 30.48 116.1546 0)
+			(at 78.74 126.3146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -254,8 +520,8 @@
 		)
 	)
 	(sheet
-		(at 91.44 55.88)
-		(size 26.67 31.75)
+		(at 78.74 55.88)
+		(size 34.29 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
@@ -270,7 +536,7 @@
 		)
 		(uuid "360b299b-84d8-4d26-8110-4c6e53cc9fa4")
 		(property "Sheetname" "Power Tree"
-			(at 91.44 55.1684 0)
+			(at 78.74 55.1684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -279,7 +545,7 @@
 			)
 		)
 		(property "Sheetfile" "power_tree.kicad_sch"
-			(at 91.44 88.2146 0)
+			(at 78.74 88.2146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -288,7 +554,7 @@
 			)
 		)
 		(pin "3V3_VCC" output
-			(at 118.11 60.96 0)
+			(at 113.03 60.96 0)
 			(uuid "98a367d8-6e8f-472a-9df2-aa85cc2f3fed")
 			(effects
 				(font
@@ -298,7 +564,7 @@
 			)
 		)
 		(pin "3V3_VCCA" output
-			(at 118.11 64.77 0)
+			(at 113.03 64.77 0)
 			(uuid "e8ecc318-2227-4694-8434-a41d842b7e92")
 			(effects
 				(font
@@ -307,29 +573,9 @@
 				(justify right)
 			)
 		)
-		(pin "D-" bidirectional
-			(at 118.11 76.2 0)
-			(uuid "e1f6db5c-cded-416f-b046-98f2b9862c4f")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(pin "D+" bidirectional
-			(at 118.11 72.39 0)
-			(uuid "54464d3c-ffa9-456f-8c0f-051fc76af099")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
 		(pin "USB_VCC" output
-			(at 118.11 68.58 0)
-			(uuid "d77d549d-3e8b-4258-975d-089eff866da9")
+			(at 113.03 68.58 0)
+			(uuid "54ecc873-a1f5-4347-9fe1-92926cec1428")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -346,8 +592,8 @@
 		)
 	)
 	(sheet
-		(at 161.29 96.52)
-		(size 33.02 34.29)
+		(at 161.29 93.98)
+		(size 33.02 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
@@ -362,7 +608,7 @@
 		)
 		(uuid "b4895c98-2d65-46cb-a7d2-9672cea4def2")
 		(property "Sheetname" "USB UART"
-			(at 161.29 95.8084 0)
+			(at 161.29 93.2684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -371,7 +617,7 @@
 			)
 		)
 		(property "Sheetfile" "USB_UART.kicad_sch"
-			(at 161.29 131.3946 0)
+			(at 161.29 126.3146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -379,29 +625,9 @@
 				(justify left top)
 			)
 		)
-		(pin "USBD+" bidirectional
-			(at 161.29 113.03 180)
-			(uuid "5b79c56f-979c-41f0-9fcc-0b11e87dc2ca")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(pin "USBD-" bidirectional
-			(at 161.29 118.11 180)
-			(uuid "08292427-9222-4290-b1f0-1739ed40eb8d")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(pin "USB_VCC" input
+		(pin "UART_RXD" bidirectional
 			(at 161.29 107.95 180)
-			(uuid "e9977919-8d18-47cb-9718-d339120e1b32")
+			(uuid "55866c8f-afaa-409d-9071-4996a2467be0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -410,8 +636,8 @@
 			)
 		)
 		(pin "3V3_VCC" input
-			(at 161.29 102.87 180)
-			(uuid "8544e9db-57e2-47b7-8c88-1149ac2270f0")
+			(at 161.29 100.33 180)
+			(uuid "86cdc8e4-0aee-4941-affa-aa63c95b4252")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -419,24 +645,24 @@
 				(justify left)
 			)
 		)
-		(pin "TXD" bidirectional
-			(at 194.31 107.95 0)
-			(uuid "ad4a3780-de04-4301-ae5a-12f7badd48a4")
+		(pin "UART_TXD" bidirectional
+			(at 161.29 104.14 180)
+			(uuid "e81d0045-1fd7-48fb-ad47-8ebacd8fed8b")
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
-		(pin "RXD" bidirectional
-			(at 194.31 102.87 0)
-			(uuid "9f1d0035-e4d3-47f0-a3e9-438c3b9f29cf")
+		(pin "USB_VCC" output
+			(at 161.29 96.52 180)
+			(uuid "35e89646-7621-414f-8af6-99a73da78d6d")
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
 		(instances
@@ -502,23 +728,23 @@
 			)
 		)
 		(pin "USART1_RX" bidirectional
-			(at 194.31 60.96 0)
+			(at 160.02 72.39 180)
 			(uuid "6bc50085-9f1e-4bbd-839f-a9b1bf6645e9")
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
 		(pin "USART1_TX" bidirectional
-			(at 194.31 64.77 0)
+			(at 160.02 68.58 180)
 			(uuid "5fe6aa1a-52ab-430c-b4bc-d87671d13b04")
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
 		(instances

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -703,26 +703,6 @@
 				(justify left top)
 			)
 		)
-		(pin "3V3_VCC" input
-			(at 161.29 100.33 180)
-			(uuid "86cdc8e4-0aee-4941-affa-aa63c95b4252")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(pin "USB_VCC" output
-			(at 161.29 96.52 180)
-			(uuid "35e89646-7621-414f-8af6-99a73da78d6d")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
 		(pin "UART_RXD" input
 			(at 161.29 110.49 180)
 			(uuid "3563ee22-b6ab-4804-9cf4-8bf0529be6c3")
@@ -746,6 +726,26 @@
 		(pin "RESET" input
 			(at 161.29 115.57 180)
 			(uuid "fe822fd3-8af3-459a-9361-ddcccf94c05d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "USB_VCC" passive
+			(at 161.29 96.52 180)
+			(uuid "d3a3ed0d-5c51-44c7-8b13-99fdd882e27b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "3V3_VCC" passive
+			(at 161.29 100.33 180)
+			(uuid "74c219fd-1bd1-4453-8440-3a7fed1851e7")
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -795,26 +795,6 @@
 				(justify left top)
 			)
 		)
-		(pin "VCC" input
-			(at 160.02 60.96 180)
-			(uuid "14923735-f768-42cd-9197-26c4dd180aa1")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(pin "VCCCA" input
-			(at 160.02 64.77 180)
-			(uuid "e09fd075-d708-4ce3-8fd0-be39fb7e49fc")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
 		(pin "USART1_TX" output
 			(at 160.02 68.58 180)
 			(uuid "92b58b44-b604-4668-a482-763cd062249d")
@@ -838,6 +818,26 @@
 		(pin "RESET" output
 			(at 160.02 76.2 180)
 			(uuid "41ff4177-18ab-44ec-beee-4c6138f15007")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "VCC" passive
+			(at 160.02 60.96 180)
+			(uuid "6d511e74-9b46-4639-8a80-5b1293097b1e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "VCCCA" passive
+			(at 160.02 64.77 180)
+			(uuid "048c4acd-d489-4db0-8b95-31ace6b9a6ce")
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -631,9 +631,9 @@
 				(justify left top)
 			)
 		)
-		(pin "3V3_VCC" output
+		(pin "3V3_VCC" passive
 			(at 113.03 60.96 0)
-			(uuid "98a367d8-6e8f-472a-9df2-aa85cc2f3fed")
+			(uuid "0cec6859-1259-458d-8f6e-e26c4dc22c80")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -641,9 +641,9 @@
 				(justify right)
 			)
 		)
-		(pin "3V3_VCCA" output
+		(pin "3V3_VCCA" passive
 			(at 113.03 64.77 0)
-			(uuid "e8ecc318-2227-4694-8434-a41d842b7e92")
+			(uuid "9cbd90bc-64b5-486e-b264-1509175741c7")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -651,9 +651,9 @@
 				(justify right)
 			)
 		)
-		(pin "USB_VCC" input
+		(pin "USB_VCC" passive
 			(at 113.03 68.58 0)
-			(uuid "445c9892-806d-4ecb-8773-efaf9f058e98")
+			(uuid "c5c74bf2-8f76-4298-993d-76c49a3498ef")
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -18,6 +18,15 @@
 		(uuid "2738f141-1645-4ad5-a477-fd9257e768f9")
 	)
 	(bus_entry
+		(at 147.32 74.93)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a321a8e-f506-4f1c-8b7e-8d32dde068d1")
+	)
+	(bus_entry
 		(at 124.46 63.5)
 		(size -2.54 -2.54)
 		(stroke
@@ -25,6 +34,15 @@
 			(type default)
 		)
 		(uuid "3bfede51-80d7-4e55-939c-84b0b23433ab")
+	)
+	(bus_entry
+		(at 147.32 107.95)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "46767e73-bdcc-4040-a296-a2579c23a17b")
 	)
 	(bus_entry
 		(at 147.32 97.79)
@@ -54,6 +72,24 @@
 		(uuid "69263ba3-b30b-4b16-9cbb-722e6bf19a15")
 	)
 	(bus_entry
+		(at 147.32 71.12)
+		(size 2.54 -2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "71090b36-fc0e-467f-be09-081a0bc58a53")
+	)
+	(bus_entry
+		(at 147.32 102.87)
+		(size 2.54 2.54)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92884432-44eb-4f8d-8314-f71d82b08582")
+	)
+	(bus_entry
 		(at 124.46 71.12)
 		(size -2.54 -2.54)
 		(stroke
@@ -71,61 +107,25 @@
 		)
 		(uuid "ca5cc7b8-0e47-4884-8095-582164dfd7f3")
 	)
-	(bus_entry
-		(at 147.32 101.6)
-		(size 2.54 2.54)
+	(bus
+		(pts
+			(xy 147.32 67.31) (xy 147.32 71.12)
+		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d2281c38-e3be-4ec5-9179-f402e46fe6c6")
-	)
-	(bus_entry
-		(at 147.32 71.12)
-		(size 2.54 -2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e84bbbf9-4ab5-4ea6-921a-472c8bf717f4")
-	)
-	(bus_entry
-		(at 147.32 74.93)
-		(size 2.54 -2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f606cf46-c1e4-4e58-92fa-e0e356ad98ba")
-	)
-	(bus_entry
-		(at 147.32 105.41)
-		(size 2.54 2.54)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f88d79e2-019c-4b46-b9a4-deb04d416635")
+		(uuid "00c7b0ad-a963-422e-bbab-4991f6f935b6")
 	)
 	(bus
 		(pts
-			(xy 147.32 97.79) (xy 147.32 101.6)
+			(xy 147.32 97.79) (xy 147.32 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "0cd7215b-1862-4136-b7aa-c1dc57958fac")
-	)
-	(bus
-		(pts
-			(xy 147.32 71.12) (xy 147.32 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0f23a3a5-69fa-408b-8f66-63d36d021eb8")
 	)
 	(wire
 		(pts
@@ -149,26 +149,6 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 72.39) (xy 160.02 72.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2c2895a6-407f-45be-a094-cfb8246eaea2")
-	)
-	(wire
-		(pts
-			(xy 149.86 68.58) (xy 160.02 68.58)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2ec20c22-53ce-48cf-999d-4df84acdb8d8")
-	)
-	(wire
-		(pts
 			(xy 149.86 100.33) (xy 161.29 100.33)
 		)
 		(stroke
@@ -176,16 +156,6 @@
 			(type default)
 		)
 		(uuid "31f13dfd-2b35-4185-8562-fd362a46af4f")
-	)
-	(wire
-		(pts
-			(xy 149.86 107.95) (xy 161.29 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "33581d2a-fb03-4f9c-84a5-dc06495d0a13")
 	)
 	(wire
 		(pts
@@ -237,6 +207,16 @@
 		)
 		(uuid "53abe7c9-26f7-471b-8b30-0ec648e089e5")
 	)
+	(wire
+		(pts
+			(xy 149.86 72.39) (xy 160.02 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e719543-36f4-4bae-88c2-abdaaad6d8f9")
+	)
 	(bus
 		(pts
 			(xy 124.46 57.15) (xy 147.32 57.15)
@@ -246,6 +226,16 @@
 			(type default)
 		)
 		(uuid "5f33a242-6c1a-4d9e-bf0e-b0ffdd784e69")
+	)
+	(bus
+		(pts
+			(xy 147.32 71.12) (xy 147.32 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "648ccb8f-1ed8-4024-938e-6c98273fcc85")
 	)
 	(wire
 		(pts
@@ -269,16 +259,6 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 105.41) (xy 147.32 128.27)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "9d161b5c-ad7c-4dc6-93de-8a96b1a53483")
-	)
-	(bus
-		(pts
 			(xy 124.46 67.31) (xy 124.46 63.5)
 		)
 		(stroke
@@ -286,16 +266,6 @@
 			(type default)
 		)
 		(uuid "a0a2ea45-28b0-4c9f-84f3-10624f6320d7")
-	)
-	(bus
-		(pts
-			(xy 147.32 101.6) (xy 147.32 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "aad16e27-a931-4062-8bae-2bccf721c428")
 	)
 	(wire
 		(pts
@@ -309,27 +279,7 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 74.93) (xy 147.32 93.98)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ad8f6822-5dc0-4559-abf3-ca47ddc2ceb9")
-	)
-	(wire
-		(pts
-			(xy 149.86 104.14) (xy 161.29 104.14)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b07349ef-7ce7-4d50-89c0-2c9db2fead25")
-	)
-	(bus
-		(pts
-			(xy 147.32 67.31) (xy 147.32 71.12)
+			(xy 147.32 63.5) (xy 147.32 67.31)
 		)
 		(stroke
 			(width 0)
@@ -339,13 +289,53 @@
 	)
 	(bus
 		(pts
-			(xy 147.32 63.5) (xy 147.32 67.31)
+			(xy 147.32 102.87) (xy 147.32 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d7843659-763c-4140-bd7d-564dea61ee21")
+		(uuid "b903178a-4183-4c91-99e0-e5fbbeb58515")
+	)
+	(wire
+		(pts
+			(xy 149.86 68.58) (xy 160.02 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c93a36a8-8450-42de-bf36-4693abc571a4")
+	)
+	(wire
+		(pts
+			(xy 149.86 105.41) (xy 161.29 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd1d2537-e45a-4738-ab83-a6e92c78a2d4")
+	)
+	(wire
+		(pts
+			(xy 149.86 110.49) (xy 161.29 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e73d78c8-7f10-44c8-b131-8ad3530a5fea")
+	)
+	(bus
+		(pts
+			(xy 147.32 74.93) (xy 147.32 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ecbf442e-4b4b-4559-8c70-513aaf6f2367")
 	)
 	(bus
 		(pts
@@ -357,25 +347,25 @@
 		)
 		(uuid "ef9c4b64-bb14-4b9e-a518-cebb359f13fc")
 	)
-	(label "UART_RXD"
-		(at 160.02 68.58 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
+	(bus
+		(pts
+			(xy 147.32 107.95) (xy 147.32 128.27)
 		)
-		(uuid "075699bf-9c3a-4420-9e62-e8785c0d28e2")
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f034d32a-1490-4915-b13a-f6167f54a09a")
 	)
 	(label "UART_RXD"
-		(at 161.29 107.95 180)
+		(at 161.29 110.49 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify right bottom)
 		)
-		(uuid "09ff394b-6ec1-4843-a9fd-17f1e71c3a00")
+		(uuid "06a0e1f0-4df2-435c-86e0-e3c63aec5e29")
 	)
 	(label "VCC "
 		(at 113.03 60.96 0)
@@ -386,6 +376,16 @@
 			(justify left bottom)
 		)
 		(uuid "10eedda6-d548-42f3-8fd2-047ac8260ff8")
+	)
+	(label "UART_TXD"
+		(at 160.02 72.39 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "288a77ce-b1f2-4ea0-9bd2-8eb367f58318")
 	)
 	(label "USB_VCC"
 		(at 161.29 96.52 180)
@@ -407,6 +407,16 @@
 		)
 		(uuid "3478ce2b-77ab-43b1-b4d9-55df0e02803d")
 	)
+	(label "UART_RXD"
+		(at 160.02 68.58 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "66f0e338-4c75-48b8-a194-8c638ee167b6")
+	)
 	(label "VCC "
 		(at 160.02 60.96 180)
 		(effects
@@ -416,26 +426,6 @@
 			(justify right bottom)
 		)
 		(uuid "9be7556e-95f0-449b-90fd-2d444ce9e89d")
-	)
-	(label "UART_TXD"
-		(at 161.29 104.14 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "a19cdb85-dca3-459b-8e0f-5fa9f966cbc6")
-	)
-	(label "UART_TXD"
-		(at 160.02 72.39 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "a3368c74-6e84-422e-9bda-ae584f3a2b5e")
 	)
 	(label "VCC "
 		(at 161.29 100.33 180)
@@ -466,6 +456,16 @@
 			(justify left bottom)
 		)
 		(uuid "ecc0faa9-d431-4c65-a418-b0c7d64dfe74")
+	)
+	(label "UART_TXD"
+		(at 161.29 105.41 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "f4184472-4e53-47a8-a434-560161f10e7c")
 	)
 	(label "VCCA"
 		(at 160.02 64.77 180)
@@ -625,16 +625,6 @@
 				(justify left top)
 			)
 		)
-		(pin "UART_RXD" bidirectional
-			(at 161.29 107.95 180)
-			(uuid "55866c8f-afaa-409d-9071-4996a2467be0")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
 		(pin "3V3_VCC" input
 			(at 161.29 100.33 180)
 			(uuid "86cdc8e4-0aee-4941-affa-aa63c95b4252")
@@ -645,9 +635,9 @@
 				(justify left)
 			)
 		)
-		(pin "UART_TXD" bidirectional
-			(at 161.29 104.14 180)
-			(uuid "e81d0045-1fd7-48fb-ad47-8ebacd8fed8b")
+		(pin "USB_VCC" output
+			(at 161.29 96.52 180)
+			(uuid "35e89646-7621-414f-8af6-99a73da78d6d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -655,9 +645,19 @@
 				(justify left)
 			)
 		)
-		(pin "USB_VCC" output
-			(at 161.29 96.52 180)
-			(uuid "35e89646-7621-414f-8af6-99a73da78d6d")
+		(pin "UART_RXD" input
+			(at 161.29 110.49 180)
+			(uuid "3563ee22-b6ab-4804-9cf4-8bf0529be6c3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "UART_TXD" output
+			(at 161.29 105.41 180)
+			(uuid "9f13a2cc-3a2d-44b4-86e8-06f1620e8fd1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -727,9 +727,9 @@
 				(justify left)
 			)
 		)
-		(pin "USART1_RX" bidirectional
-			(at 160.02 72.39 180)
-			(uuid "6bc50085-9f1e-4bbd-839f-a9b1bf6645e9")
+		(pin "USART1_TX" output
+			(at 160.02 68.58 180)
+			(uuid "92b58b44-b604-4668-a482-763cd062249d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -737,9 +737,9 @@
 				(justify left)
 			)
 		)
-		(pin "USART1_TX" bidirectional
-			(at 160.02 68.58 180)
-			(uuid "5fe6aa1a-52ab-430c-b4bc-d87671d13b04")
+		(pin "USART1_RX" input
+			(at 160.02 72.39 180)
+			(uuid "adecbd38-3841-4fa6-ab6c-21ea6721c5aa")
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/HW.kicad_sch
+++ b/HW.kicad_sch
@@ -5,28 +5,214 @@
 	(uuid "01550cd7-b424-469c-925b-c370f3609cd4")
 	(paper "A4")
 	(lib_symbols)
-	(wire
-		(pts
-			(xy 134.62 104.14) (xy 162.56 104.14)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "209960d9-6a4b-4f6b-a344-d7bdee96181b")
+	(junction
+		(at 146.05 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3c3cdb30-3c67-43fa-9900-f6ded5d82ddb")
 	)
 	(wire
 		(pts
-			(xy 134.62 100.33) (xy 162.56 100.33)
+			(xy 118.11 60.96) (xy 146.05 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "69cd79e0-d859-4ab3-a796-d706fe6550b7")
+		(uuid "0641a97e-7748-44cd-be88-338a9ff6ab6f")
+	)
+	(wire
+		(pts
+			(xy 118.11 68.58) (xy 140.97 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "08374c0f-6684-44e2-9371-427fe6af03ac")
+	)
+	(wire
+		(pts
+			(xy 194.31 107.95) (xy 203.2 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10200d5d-7cc6-4609-b53c-cc807d72f430")
+	)
+	(wire
+		(pts
+			(xy 199.39 102.87) (xy 194.31 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1086583a-cc4e-4d2c-a364-b0f9ca4866e1")
+	)
+	(wire
+		(pts
+			(xy 118.11 72.39) (xy 135.89 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "16e478f6-9c14-4728-b311-9ddf0fd7b8bb")
+	)
+	(wire
+		(pts
+			(xy 135.89 113.03) (xy 161.29 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c1988cf-062f-407f-bf8b-f9b6c00a3eb8")
+	)
+	(wire
+		(pts
+			(xy 160.02 64.77) (xy 118.11 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "205dcf13-1519-43eb-9c0b-714b4a222857")
+	)
+	(wire
+		(pts
+			(xy 135.89 72.39) (xy 135.89 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "336f38f3-09eb-4b6a-95da-b2dbe4b75ac1")
+	)
+	(wire
+		(pts
+			(xy 130.81 76.2) (xy 130.81 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34f16098-1fec-4adb-b2dc-ac97c76c551b")
+	)
+	(wire
+		(pts
+			(xy 194.31 60.96) (xy 203.2 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "439a16b7-f968-484e-a2bc-fcf271807644")
+	)
+	(wire
+		(pts
+			(xy 146.05 60.96) (xy 160.02 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52c8e71f-10c7-4e71-8766-4141f998d50a")
+	)
+	(wire
+		(pts
+			(xy 203.2 107.95) (xy 203.2 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "703a083e-2119-4541-b1f1-68eb69555519")
+	)
+	(wire
+		(pts
+			(xy 118.11 76.2) (xy 130.81 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f1bf33c-de20-4e35-a7f3-bef6eba58ee4")
+	)
+	(wire
+		(pts
+			(xy 140.97 107.95) (xy 161.29 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "82252ba9-dfd2-441f-b88e-d058abae3566")
+	)
+	(wire
+		(pts
+			(xy 130.81 118.11) (xy 161.29 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9ba78704-d088-458c-b7e5-b018d7ba5de4")
+	)
+	(wire
+		(pts
+			(xy 140.97 68.58) (xy 140.97 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9fbe4586-b4f6-4d38-81ca-037ac33413d2")
+	)
+	(wire
+		(pts
+			(xy 146.05 102.87) (xy 161.29 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abbd5a1e-f21c-45d2-a004-765a8e06498c")
+	)
+	(wire
+		(pts
+			(xy 146.05 60.96) (xy 146.05 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be540f7c-9553-442d-9d1d-f3e68a225b77")
+	)
+	(wire
+		(pts
+			(xy 199.39 64.77) (xy 199.39 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2a72250-15d2-4ea8-92f5-23e9096cac2e")
+	)
+	(wire
+		(pts
+			(xy 194.31 64.77) (xy 199.39 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f2f619f1-65b4-4b45-a7cd-bbb2279ab3d8")
 	)
 	(sheet
-		(at 93.98 46.99)
+		(at 30.48 83.82)
 		(size 39.37 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -42,7 +228,7 @@
 		)
 		(uuid "2dab47df-4ca4-4373-b48e-0efc8c61f605")
 		(property "Sheetname" "LoRA Module"
-			(at 93.98 46.2784 0)
+			(at 30.48 83.1084 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -51,7 +237,7 @@
 			)
 		)
 		(property "Sheetfile" "lora_module.kicad_sch"
-			(at 93.98 79.3246 0)
+			(at 30.48 116.1546 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68,8 +254,8 @@
 		)
 	)
 	(sheet
-		(at 107.95 95.25)
-		(size 26.67 15.24)
+		(at 91.44 55.88)
+		(size 26.67 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
@@ -84,7 +270,7 @@
 		)
 		(uuid "360b299b-84d8-4d26-8110-4c6e53cc9fa4")
 		(property "Sheetname" "Power Tree"
-			(at 107.95 94.5384 0)
+			(at 91.44 55.1684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93,7 +279,7 @@
 			)
 		)
 		(property "Sheetfile" "power_tree.kicad_sch"
-			(at 107.95 111.0746 0)
+			(at 91.44 88.2146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102,7 +288,7 @@
 			)
 		)
 		(pin "3V3_VCC" output
-			(at 134.62 100.33 0)
+			(at 118.11 60.96 0)
 			(uuid "98a367d8-6e8f-472a-9df2-aa85cc2f3fed")
 			(effects
 				(font
@@ -112,8 +298,38 @@
 			)
 		)
 		(pin "3V3_VCCA" output
-			(at 134.62 104.14 0)
+			(at 118.11 64.77 0)
 			(uuid "e8ecc318-2227-4694-8434-a41d842b7e92")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "D-" bidirectional
+			(at 118.11 76.2 0)
+			(uuid "e1f6db5c-cded-416f-b046-98f2b9862c4f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "D+" bidirectional
+			(at 118.11 72.39 0)
+			(uuid "54464d3c-ffa9-456f-8c0f-051fc76af099")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "USB_VCC" output
+			(at 118.11 68.58 0)
+			(uuid "d77d549d-3e8b-4258-975d-089eff866da9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -130,8 +346,110 @@
 		)
 	)
 	(sheet
-		(at 162.56 95.25)
-		(size 36.83 31.75)
+		(at 161.29 96.52)
+		(size 33.02 34.29)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0.0000)
+		)
+		(uuid "b4895c98-2d65-46cb-a7d2-9672cea4def2")
+		(property "Sheetname" "USB UART"
+			(at 161.29 95.8084 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "USB_UART.kicad_sch"
+			(at 161.29 131.3946 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "USBD+" bidirectional
+			(at 161.29 113.03 180)
+			(uuid "5b79c56f-979c-41f0-9fcc-0b11e87dc2ca")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "USBD-" bidirectional
+			(at 161.29 118.11 180)
+			(uuid "08292427-9222-4290-b1f0-1739ed40eb8d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "USB_VCC" input
+			(at 161.29 107.95 180)
+			(uuid "e9977919-8d18-47cb-9718-d339120e1b32")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "3V3_VCC" input
+			(at 161.29 102.87 180)
+			(uuid "8544e9db-57e2-47b7-8c88-1149ac2270f0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "TXD" bidirectional
+			(at 194.31 107.95 0)
+			(uuid "ad4a3780-de04-4301-ae5a-12f7badd48a4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "RXD" bidirectional
+			(at 194.31 102.87 0)
+			(uuid "9f1d0035-e4d3-47f0-a3e9-438c3b9f29cf")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4"
+					(page "5")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 160.02 55.88)
+		(size 34.29 31.75)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
@@ -146,7 +464,7 @@
 		)
 		(uuid "edb1e4c3-83a3-4443-aa4b-0e758d3bea47")
 		(property "Sheetname" "MCU"
-			(at 162.56 94.5384 0)
+			(at 160.02 55.1684 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -155,7 +473,7 @@
 			)
 		)
 		(property "Sheetfile" "mcu.kicad_sch"
-			(at 162.56 127.5846 0)
+			(at 160.02 88.2146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -164,7 +482,7 @@
 			)
 		)
 		(pin "VCC" input
-			(at 162.56 100.33 180)
+			(at 160.02 60.96 180)
 			(uuid "14923735-f768-42cd-9197-26c4dd180aa1")
 			(effects
 				(font
@@ -174,13 +492,33 @@
 			)
 		)
 		(pin "VCCCA" input
-			(at 162.56 104.14 180)
+			(at 160.02 64.77 180)
 			(uuid "e09fd075-d708-4ce3-8fd0-be39fb7e49fc")
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left)
+			)
+		)
+		(pin "USART1_RX" bidirectional
+			(at 194.31 60.96 0)
+			(uuid "6bc50085-9f1e-4bbd-839f-a9b1bf6645e9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "USART1_TX" bidirectional
+			(at 194.31 64.77 0)
+			(uuid "5fe6aa1a-52ab-430c-b4bc-d87671d13b04")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
 			)
 		)
 		(instances

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -3257,7 +3257,7 @@
 				(justify right)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
 			(at 209.55 26.67 0)
 			(effects
 				(font
@@ -3600,7 +3600,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
 			(at 226.822 36.83 90)
 			(effects
 				(font
@@ -3934,7 +3934,7 @@
 				(justify right)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
 			(at 228.6 26.67 0)
 			(effects
 				(font
@@ -4013,7 +4013,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
 			(at 188.722 36.83 90)
 			(effects
 				(font
@@ -4083,7 +4083,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
 			(at 207.772 36.83 90)
 			(effects
 				(font
@@ -4153,7 +4153,7 @@
 				(justify right)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
 			(at 190.5 26.67 0)
 			(effects
 				(font

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -2054,6 +2054,19 @@
 		)
 		(uuid "9a8debe4-39bc-44c5-8724-9a582d6e3bac")
 	)
+	(text "note: an upstream facing port \nis connected like this to use \nUSB Type-C charging of 1.5A@5V"
+		(exclude_from_sim no)
+		(at 247.396 51.816 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.1588)
+				(color 0 0 0 1)
+			)
+			(justify left)
+		)
+		(uuid "b1257d3e-b11a-40fe-a824-c685665f3815")
+	)
 	(text "Reset In\n"
 		(exclude_from_sim no)
 		(at 51.562 17.526 0)
@@ -2222,7 +2235,7 @@
 	)
 	(polyline
 		(pts
-			(xy 203.2 12.7) (xy 203.2 52.07)
+			(xy 203.2 12.7) (xy 203.2 55.88)
 		)
 		(stroke
 			(width 0)
@@ -2395,7 +2408,7 @@
 	)
 	(polyline
 		(pts
-			(xy 284.48 52.07) (xy 242.57 52.07)
+			(xy 284.48 55.88) (xy 242.57 55.88)
 		)
 		(stroke
 			(width 0)
@@ -2416,7 +2429,7 @@
 	)
 	(polyline
 		(pts
-			(xy 242.57 52.07) (xy 203.2 52.07)
+			(xy 242.57 55.88) (xy 203.2 55.88)
 		)
 		(stroke
 			(width 0)
@@ -2619,7 +2632,7 @@
 	)
 	(polyline
 		(pts
-			(xy 242.57 52.07) (xy 242.57 12.7)
+			(xy 242.57 55.88) (xy 242.57 12.7)
 		)
 		(stroke
 			(width 0)

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -1,0 +1,1736 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(uuid "a8d1e452-9f3c-4588-8933-90e5366ec578")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Interface_USB:FT232RL"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at -16.51 22.86 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "FT232RL"
+				(at 10.16 22.86 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_SO:SSOP-28_5.3x10.2mm_P0.65mm"
+				(at 27.94 -22.86 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT232R.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "USB to Serial Interface, SSOP-28"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "FTDI USB Serial"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "SSOP*5.3x10.2mm*P0.65mm*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "FT232RL_0_1"
+				(rectangle
+					(start -16.51 21.59)
+					(end 16.51 -21.59)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "FT232RL_1_1"
+				(pin power_out line
+					(at -20.32 17.78 0)
+					(length 3.81)
+					(name "3V3OUT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 10.16 0)
+					(length 3.81)
+					(name "USBD+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 7.62 0)
+					(length 3.81)
+					(name "USBD-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -20.32 0 0)
+					(length 3.81)
+					(name "~{RESET}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -20.32 -5.08 0)
+					(length 3.81)
+					(name "OSCI"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -20.32 -10.16 0)
+					(length 3.81)
+					(name "OSCO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -20.32 -17.78 0)
+					(length 3.81)
+					(name "TEST"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -5.08 -25.4 90)
+					(length 3.81)
+					(name "AGND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -2.54 25.4 270)
+					(length 3.81)
+					(name "VCCIO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -25.4 90)
+					(length 3.81)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 2.54 25.4 270)
+					(length 3.81)
+					(name "VCC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 2.54 -25.4 90)
+					(length 3.81)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 5.08 -25.4 90)
+					(length 3.81)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 20.32 17.78 180)
+					(length 3.81)
+					(name "TXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 20.32 15.24 180)
+					(length 3.81)
+					(name "RXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output output_low
+					(at 20.32 12.7 180)
+					(length 3.81)
+					(name "RTS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input input_low
+					(at 20.32 10.16 180)
+					(length 3.81)
+					(name "CTS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output output_low
+					(at 20.32 7.62 180)
+					(length 3.81)
+					(name "DTR"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input input_low
+					(at 20.32 5.08 180)
+					(length 3.81)
+					(name "DCR"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input input_low
+					(at 20.32 2.54 180)
+					(length 3.81)
+					(name "DCD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input input_low
+					(at 20.32 0 180)
+					(length 3.81)
+					(name "RI"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 20.32 -7.62 180)
+					(length 3.81)
+					(name "CBUS0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 20.32 -10.16 180)
+					(length 3.81)
+					(name "CBUS1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 20.32 -12.7 180)
+					(length 3.81)
+					(name "CBUS2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 20.32 -15.24 180)
+					(length 3.81)
+					(name "CBUS3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 20.32 -17.78 180)
+					(length 3.81)
+					(name "CBUS4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:VCC"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "VCC"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"VCC\""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "VCC_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "VCC_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "Power In"
+		(exclude_from_sim no)
+		(at 18.542 17.018 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.1588)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "c95dae2c-3365-451e-a5a9-c01d62a8daab")
+	)
+	(junction
+		(at 140.97 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4518b166-ee3f-46bc-bb6f-409c1b5a81d9")
+	)
+	(junction
+		(at 146.05 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a5c1f6e9-cb4d-434b-886b-9cdc00cd41a2")
+	)
+	(junction
+		(at 148.59 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ef8f5390-5bab-4421-a2c4-421a0cf5a7ef")
+	)
+	(no_connect
+		(at 166.37 72.39)
+		(uuid "517e1990-205b-45e1-86c1-ba379163f2ab")
+	)
+	(no_connect
+		(at 166.37 95.25)
+		(uuid "8fae41a0-0e47-41d7-9422-25263397e7e7")
+	)
+	(no_connect
+		(at 125.73 90.17)
+		(uuid "9be4298f-6fb6-4efd-b86e-51ac092eb9f7")
+	)
+	(no_connect
+		(at 166.37 77.47)
+		(uuid "a0b023d3-ef01-4828-806e-30f6f31a5b41")
+	)
+	(no_connect
+		(at 166.37 87.63)
+		(uuid "ac653252-6bd7-4084-b413-d8ff41adb071")
+	)
+	(no_connect
+		(at 166.37 69.85)
+		(uuid "ad748d64-dbe4-4dba-bb38-04d415cd6964")
+	)
+	(no_connect
+		(at 166.37 90.17)
+		(uuid "af5f79da-93b2-404c-878b-97703347a6b4")
+	)
+	(no_connect
+		(at 166.37 74.93)
+		(uuid "b6afa0c8-9acc-43f8-96f9-c65cf4252a57")
+	)
+	(no_connect
+		(at 166.37 80.01)
+		(uuid "bd7f7341-8760-47fb-ad7d-362895cbef2b")
+	)
+	(no_connect
+		(at 125.73 85.09)
+		(uuid "ce1c43fe-49fe-4733-9524-b8a94dbf15fb")
+	)
+	(no_connect
+		(at 125.73 80.01)
+		(uuid "d2fa6037-2b7d-4e48-9b25-91c295893506")
+	)
+	(no_connect
+		(at 166.37 97.79)
+		(uuid "e53bb683-7eb9-4998-b51b-c90fa818d7db")
+	)
+	(no_connect
+		(at 166.37 67.31)
+		(uuid "f06ebede-3bff-43ce-829a-3d61417c8ae8")
+	)
+	(no_connect
+		(at 166.37 92.71)
+		(uuid "f512327e-0d35-4b5c-8c1a-fafb6bc3a42c")
+	)
+	(wire
+		(pts
+			(xy 148.59 105.41) (xy 151.13 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1fcdc215-11b5-4c84-bb04-d1165c5c8eee")
+	)
+	(wire
+		(pts
+			(xy 119.38 72.39) (xy 125.73 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "39663861-680f-4c75-972b-6cf7d46ba0fb")
+	)
+	(wire
+		(pts
+			(xy 166.37 64.77) (xy 172.72 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5cdba394-2374-4284-b90b-6a617011f536")
+	)
+	(wire
+		(pts
+			(xy 119.38 69.85) (xy 125.73 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62c1c7ca-7d20-4041-9ec7-24e03927f4e0")
+	)
+	(wire
+		(pts
+			(xy 143.51 48.26) (xy 143.51 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "63129712-d053-4f60-92dc-395cc4a95b67")
+	)
+	(wire
+		(pts
+			(xy 166.37 62.23) (xy 172.72 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6323a3c3-acb6-4c43-9213-29f664580090")
+	)
+	(wire
+		(pts
+			(xy 101.6 69.85) (xy 101.6 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7212c7e6-b78f-48ff-bb6f-9f02b39d8e1f")
+	)
+	(polyline
+		(pts
+			(xy 38.1 39.37) (xy 38.1 12.7)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "7219083e-22c4-47db-97ca-462a0c85a00e")
+	)
+	(wire
+		(pts
+			(xy 148.59 49.53) (xy 148.59 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "782c9c2f-e5ed-442d-981a-a084456c4223")
+	)
+	(wire
+		(pts
+			(xy 140.97 105.41) (xy 146.05 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "896dfffa-bb31-4656-9c25-c1d08e94de49")
+	)
+	(wire
+		(pts
+			(xy 24.13 35.56) (xy 33.02 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8a4aa539-9a86-4c51-bf8d-bfc3e13fe88b")
+	)
+	(wire
+		(pts
+			(xy 125.73 97.79) (xy 125.73 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9b093f9b-346f-4ce0-8dd4-e5ee3e43cce5")
+	)
+	(wire
+		(pts
+			(xy 33.02 29.21) (xy 33.02 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2821313-c254-49c0-a6f5-721f0268bfc4")
+	)
+	(wire
+		(pts
+			(xy 101.6 62.23) (xy 125.73 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "af8cd4bb-1848-4d31-a7a4-86b7c4d4882d")
+	)
+	(wire
+		(pts
+			(xy 140.97 105.41) (xy 140.97 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c789bc7e-6645-48b6-8b16-76a61aa07d89")
+	)
+	(polyline
+		(pts
+			(xy 10.16 39.37) (xy 38.1 39.37)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "d40401e2-b68c-4156-ad01-caa03f51d41d")
+	)
+	(wire
+		(pts
+			(xy 146.05 105.41) (xy 148.59 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dcefc9fb-17da-4039-9b71-eb8ea20024f7")
+	)
+	(wire
+		(pts
+			(xy 125.73 105.41) (xy 140.97 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f3971de1-cf29-45cc-bfaa-6e41f89330a7")
+	)
+	(hierarchical_label "USBD+"
+		(shape bidirectional)
+		(at 119.38 69.85 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2094b287-bb90-45b1-baad-25d54db5136b")
+	)
+	(hierarchical_label "3V3_VCC"
+		(shape input)
+		(at 143.51 48.26 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3ffd6bca-4c91-423b-8fa7-7f4ca7ee9bbe")
+	)
+	(hierarchical_label "TXD"
+		(shape bidirectional)
+		(at 172.72 62.23 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7112fe62-6f9d-4ef5-a2bb-2a43f03cf5f7")
+	)
+	(hierarchical_label "USBD-"
+		(shape bidirectional)
+		(at 119.38 72.39 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8fc3ca9e-06bb-46d8-8811-abe58b55c928")
+	)
+	(hierarchical_label "USB_VCC"
+		(shape input)
+		(at 24.13 35.56 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c6d0db75-de7f-4394-a203-3354e9d8054a")
+	)
+	(hierarchical_label "RXD"
+		(shape bidirectional)
+		(at 172.72 64.77 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d9e3a63f-de3c-4379-a102-4b09abf7cf24")
+	)
+	(symbol
+		(lib_id "Interface_USB:FT232RL")
+		(at 146.05 80.01 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "15c4b925-67bb-4e74-a707-79a35bc8a954")
+		(property "Reference" "U4"
+			(at 150.7333 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "FT232RL"
+			(at 150.7333 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:SSOP-28_5.3x10.2mm_P0.65mm"
+			(at 173.99 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://ftdichip.com/wp-content/uploads/2020/08/DS_FT232R.pdf"
+			(at 146.05 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "USB to Serial Interface, SSOP-28"
+			(at 146.05 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "25"
+			(uuid "3fa6bbbd-1765-49ec-9fac-c30d5cf13940")
+		)
+		(pin "5"
+			(uuid "38d7175d-36a4-4e15-82a9-0dd1a00667ce")
+		)
+		(pin "3"
+			(uuid "7f38aa27-9273-4c0b-bc3a-5306b30a11a7")
+		)
+		(pin "18"
+			(uuid "61870544-0e21-4d7d-8473-cd4aeabd8f52")
+		)
+		(pin "14"
+			(uuid "7a7c6863-47ed-4a17-8aa1-4e40e1280940")
+		)
+		(pin "19"
+			(uuid "b5634f2c-b6ba-4262-9a07-db46f96f7e80")
+		)
+		(pin "12"
+			(uuid "868d31f3-4bfc-482e-8513-907cea95f5f8")
+		)
+		(pin "16"
+			(uuid "8084c6e3-b0ae-4bf5-a7de-035ee2fcdcdc")
+		)
+		(pin "2"
+			(uuid "d8cbf886-432f-4bab-9e9b-8ff49cc0e14c")
+		)
+		(pin "22"
+			(uuid "e59deb45-e3c7-4043-b51b-8acda4c017e0")
+		)
+		(pin "6"
+			(uuid "fd6ccff7-1d4a-4814-b785-ceb151d70749")
+		)
+		(pin "23"
+			(uuid "71822d80-6eba-4e07-a6f3-be2d48e45a9a")
+		)
+		(pin "13"
+			(uuid "2b5259f3-b47c-4c20-b29d-49adbfd12f3c")
+		)
+		(pin "27"
+			(uuid "38ec426a-1943-4a5e-a434-2fff9f5eb62f")
+		)
+		(pin "28"
+			(uuid "5f9fac58-99fc-4477-aef2-7d6ef06e0414")
+		)
+		(pin "26"
+			(uuid "03445c7c-4dbb-4a8f-abc3-f49aeb057c55")
+		)
+		(pin "21"
+			(uuid "425ba5f5-409c-42e9-af87-86d990f9c2d3")
+		)
+		(pin "1"
+			(uuid "bdb1a078-e3a6-4608-a524-e5f28a77e306")
+		)
+		(pin "11"
+			(uuid "2fe8d70e-8b00-4708-af99-746bce637176")
+		)
+		(pin "20"
+			(uuid "c144bd2f-5d9c-4012-944a-4ddf7914d769")
+		)
+		(pin "9"
+			(uuid "9d9f2f98-46f1-44c5-be2a-e3aa52b178da")
+		)
+		(pin "10"
+			(uuid "f547e93c-ae26-4ed6-b0da-9f3e97bdba66")
+		)
+		(pin "4"
+			(uuid "9a12064e-4240-4161-8e5e-4bca67f6bcb5")
+		)
+		(pin "15"
+			(uuid "be109460-2141-410b-9a6e-836814c10bcd")
+		)
+		(pin "17"
+			(uuid "2438cfec-c2ba-4b04-affa-79eb2525259f")
+		)
+		(pin "7"
+			(uuid "96e65ca3-eda7-4543-924e-e1e8a578e5b5")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "U4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 33.02 29.21 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2fc06c0f-ce05-463a-88e8-0652f6c3ff9a")
+		(property "Reference" "#PWR030"
+			(at 33.02 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 33.02 24.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 33.02 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 33.02 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 33.02 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9d2d1095-fdd2-47b0-98e6-d54c637d319a")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR030")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 148.59 49.53 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7739b787-c7b0-40d2-af42-62bfaf27bf0b")
+		(property "Reference" "#PWR029"
+			(at 148.59 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 148.59 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 148.59 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 148.59 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 148.59 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5a36e022-eb7f-4813-bd13-489f67b6f1b3")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR029")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 101.6 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7abd2af0-feae-4957-9061-75c61bea0233")
+		(property "Reference" "#PWR025"
+			(at 101.6 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 101.6 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 101.6 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 101.6 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 101.6 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "29845e95-39ac-487a-ad14-c9dd11c73cde")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR025")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 101.6 66.04 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bc8b059e-14e3-48a3-b08d-944f5a78758e")
+		(property "Reference" "C8"
+			(at 105.41 64.7699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 105.41 67.3099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 102.5652 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 101.6 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 101.6 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1017b4a5-0a41-435d-bfd0-44ac9220aba2")
+		)
+		(pin "2"
+			(uuid "e9d58fae-3a50-4c8f-9870-d28809364e75")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "C8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 140.97 111.76 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e1399685-994c-44d8-8173-5fb6616101d6")
+		(property "Reference" "#PWR031"
+			(at 140.97 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 140.97 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 140.97 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 140.97 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 140.97 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "94a34277-79b1-47fe-b061-94a55844b778")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR031")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -2834,7 +2834,7 @@
 		(uuid "ecdaef53-1c8f-469b-a200-8bbb172a16bb")
 	)
 	(hierarchical_label "3V3_VCC"
-		(shape input)
+		(shape passive)
 		(at 199.39 77.47 90)
 		(effects
 			(font
@@ -2867,7 +2867,7 @@
 		(uuid "a614b151-2071-4746-878c-31aebcd12102")
 	)
 	(hierarchical_label "USB_VCC"
-		(shape output)
+		(shape passive)
 		(at 24.13 35.56 180)
 		(effects
 			(font

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -5,6 +5,703 @@
 	(uuid "a8d1e452-9f3c-4588-8933-90e5366ec578")
 	(paper "A4")
 	(lib_symbols
+		(symbol "Connector:USB_C_Receptacle_USB2.0_16P"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 22.225 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "USB_C_Receptacle_USB2.0_16P"
+				(at 0 19.685 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 3.81 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
+				(at 3.81 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "USB 2.0-only 16P Type-C Receptacle connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "usb universal serial bus type-C USB2.0"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "USB*C*Receptacle*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_16P_0_0"
+				(rectangle
+					(start -0.254 -17.78)
+					(end 0.254 -16.764)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 15.494)
+					(end 9.144 14.986)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 10.414)
+					(end 9.144 9.906)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 7.874)
+					(end 9.144 7.366)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 2.794)
+					(end 9.144 2.286)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 0.254)
+					(end 9.144 -0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -2.286)
+					(end 9.144 -2.794)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -4.826)
+					(end 9.144 -5.334)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -12.446)
+					(end 9.144 -12.954)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -14.986)
+					(end 9.144 -15.494)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_16P_0_1"
+				(rectangle
+					(start -10.16 17.78)
+					(end 10.16 -17.78)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy -8.89 -3.81) (xy -8.89 3.81)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -7.62 -3.81)
+					(end -6.35 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start -7.62 3.81)
+					(mid -6.985 4.4423)
+					(end -6.35 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -7.62 3.81)
+					(mid -6.985 4.4423)
+					(end -6.35 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start -8.89 3.81)
+					(mid -6.985 5.7067)
+					(end -5.08 3.81)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -5.08 -3.81)
+					(mid -6.985 -5.7067)
+					(end -8.89 -3.81)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -6.35 -3.81)
+					(mid -6.985 -4.4423)
+					(end -7.62 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -6.35 -3.81)
+					(mid -6.985 -4.4423)
+					(end -7.62 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -5.08 3.81) (xy -5.08 -3.81)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -2.54 1.143)
+					(radius 0.635)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 4.318) (xy 0 6.858) (xy 1.27 4.318) (xy -1.27 4.318)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -2.032) (xy 2.54 0.508) (xy 2.54 1.778)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -3.302) (xy -2.54 -0.762) (xy -2.54 0.508)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -5.842) (xy 0 4.318)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 -5.842)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 1.905 1.778)
+					(end 3.175 3.048)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_16P_1_1"
+				(pin passive line
+					(at -7.62 -22.86 90)
+					(length 5.08)
+					(name "SHIELD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(hide yes)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(hide yes)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(hide yes)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 10.16 180)
+					(length 5.08)
+					(name "CC1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 7.62 180)
+					(length 5.08)
+					(name "CC2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 2.54 180)
+					(length 5.08)
+					(name "D-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 0 180)
+					(length 5.08)
+					(name "D-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -2.54 180)
+					(length 5.08)
+					(name "D+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -5.08 180)
+					(length 5.08)
+					(name "D+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -12.7 180)
+					(length 5.08)
+					(name "SBU1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -15.24 180)
+					(length 5.08)
+					(name "SBU2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Device:C"
 			(pin_numbers
 				(hide yes)
@@ -126,6 +823,130 @@
 				(pin passive line
 					(at 0 -3.81 90)
 					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
 					(name "~"
 						(effects
 							(font
@@ -797,6 +1618,107 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "power:GNDA"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "GNDA"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "GNDA_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GNDA_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "power:VCC"
 			(power)
 			(pin_numbers
@@ -923,7 +1845,7 @@
 			(embedded_fonts no)
 		)
 	)
-	(text "Power In"
+	(text "Power Out\n"
 		(exclude_from_sim no)
 		(at 18.542 17.018 0)
 		(effects
@@ -936,82 +1858,130 @@
 		(uuid "c95dae2c-3365-451e-a5a9-c01d62a8daab")
 	)
 	(junction
-		(at 140.97 105.41)
+		(at 102.87 93.98)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "4518b166-ee3f-46bc-bb6f-409c1b5a81d9")
+		(uuid "3400ef6b-ed27-498b-b1cb-69fad5c36855")
 	)
 	(junction
-		(at 146.05 105.41)
+		(at 102.87 88.9)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "a5c1f6e9-cb4d-434b-886b-9cdc00cd41a2")
+		(uuid "6bf1c60a-15e8-44c7-8d7f-770e0fd62223")
 	)
 	(junction
-		(at 148.59 105.41)
+		(at 196.85 116.84)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "ef8f5390-5bab-4421-a2c4-421a0cf5a7ef")
 	)
 	(no_connect
-		(at 166.37 72.39)
+		(at 214.63 83.82)
 		(uuid "517e1990-205b-45e1-86c1-ba379163f2ab")
 	)
 	(no_connect
-		(at 166.37 95.25)
+		(at 102.87 105.41)
+		(uuid "8f7c58fa-8ada-4ae6-b8df-6fdfdce6c7d9")
+	)
+	(no_connect
+		(at 214.63 106.68)
 		(uuid "8fae41a0-0e47-41d7-9422-25263397e7e7")
 	)
 	(no_connect
-		(at 125.73 90.17)
+		(at 173.99 101.6)
 		(uuid "9be4298f-6fb6-4efd-b86e-51ac092eb9f7")
 	)
 	(no_connect
-		(at 166.37 77.47)
+		(at 214.63 88.9)
 		(uuid "a0b023d3-ef01-4828-806e-30f6f31a5b41")
 	)
 	(no_connect
-		(at 166.37 87.63)
+		(at 214.63 99.06)
 		(uuid "ac653252-6bd7-4084-b413-d8ff41adb071")
 	)
 	(no_connect
-		(at 166.37 69.85)
+		(at 214.63 81.28)
 		(uuid "ad748d64-dbe4-4dba-bb38-04d415cd6964")
 	)
 	(no_connect
-		(at 166.37 90.17)
+		(at 214.63 101.6)
 		(uuid "af5f79da-93b2-404c-878b-97703347a6b4")
 	)
 	(no_connect
-		(at 166.37 74.93)
+		(at 214.63 86.36)
 		(uuid "b6afa0c8-9acc-43f8-96f9-c65cf4252a57")
 	)
 	(no_connect
-		(at 166.37 80.01)
+		(at 214.63 91.44)
 		(uuid "bd7f7341-8760-47fb-ad7d-362895cbef2b")
 	)
 	(no_connect
-		(at 125.73 85.09)
+		(at 173.99 96.52)
 		(uuid "ce1c43fe-49fe-4733-9524-b8a94dbf15fb")
 	)
 	(no_connect
-		(at 125.73 80.01)
+		(at 173.99 91.44)
 		(uuid "d2fa6037-2b7d-4e48-9b25-91c295893506")
 	)
 	(no_connect
-		(at 166.37 97.79)
+		(at 102.87 102.87)
+		(uuid "db76a7a5-23d9-4668-80a8-72bff9143d8b")
+	)
+	(no_connect
+		(at 214.63 109.22)
 		(uuid "e53bb683-7eb9-4998-b51b-c90fa818d7db")
 	)
 	(no_connect
-		(at 166.37 67.31)
+		(at 214.63 78.74)
 		(uuid "f06ebede-3bff-43ce-829a-3d61417c8ae8")
 	)
 	(no_connect
-		(at 166.37 92.71)
+		(at 214.63 104.14)
 		(uuid "f512327e-0d35-4b5c-8c1a-fafb6bc3a42c")
 	)
 	(wire
 		(pts
-			(xy 148.59 105.41) (xy 151.13 105.41)
+			(xy 102.87 82.55) (xy 114.3 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d7de10e-eb62-41f5-b34d-13bbe11768e8")
+	)
+	(wire
+		(pts
+			(xy 102.87 88.9) (xy 110.49 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "17364e56-690b-4ae0-95be-bfc9702170a0")
+	)
+	(wire
+		(pts
+			(xy 110.49 60.96) (xy 110.49 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c9d73a9-e4d1-4d49-b950-0fb51b7ac575")
+	)
+	(wire
+		(pts
+			(xy 125.73 82.55) (xy 125.73 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d3460e6-11b9-4678-a32f-479c77fa97c2")
+	)
+	(wire
+		(pts
+			(xy 196.85 116.84) (xy 199.39 116.84)
 		)
 		(stroke
 			(width 0)
@@ -1021,7 +1991,37 @@
 	)
 	(wire
 		(pts
-			(xy 119.38 72.39) (xy 125.73 72.39)
+			(xy 132.08 80.01) (xy 132.08 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "21a76361-1d4c-4bb3-8d0f-a1ba0dfbc91d")
+	)
+	(wire
+		(pts
+			(xy 102.87 93.98) (xy 110.49 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "27615f0b-8865-4439-8071-f065831d2cfc")
+	)
+	(wire
+		(pts
+			(xy 196.85 116.84) (xy 196.85 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e5ea586-c4f2-44c7-bbe3-9f38a0a4ff3a")
+	)
+	(wire
+		(pts
+			(xy 167.64 83.82) (xy 173.99 83.82)
 		)
 		(stroke
 			(width 0)
@@ -1031,7 +2031,17 @@
 	)
 	(wire
 		(pts
-			(xy 166.37 64.77) (xy 172.72 64.77)
+			(xy 102.87 93.98) (xy 102.87 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57ffb037-867d-4374-9e8c-fc13c0baeaa3")
+	)
+	(wire
+		(pts
+			(xy 214.63 76.2) (xy 220.98 76.2)
 		)
 		(stroke
 			(width 0)
@@ -1041,7 +2051,7 @@
 	)
 	(wire
 		(pts
-			(xy 119.38 69.85) (xy 125.73 69.85)
+			(xy 167.64 81.28) (xy 173.99 81.28)
 		)
 		(stroke
 			(width 0)
@@ -1051,7 +2061,7 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 48.26) (xy 143.51 54.61)
+			(xy 191.77 59.69) (xy 191.77 66.04)
 		)
 		(stroke
 			(width 0)
@@ -1061,7 +2071,7 @@
 	)
 	(wire
 		(pts
-			(xy 166.37 62.23) (xy 172.72 62.23)
+			(xy 214.63 73.66) (xy 220.98 73.66)
 		)
 		(stroke
 			(width 0)
@@ -1071,7 +2081,7 @@
 	)
 	(wire
 		(pts
-			(xy 101.6 69.85) (xy 101.6 76.2)
+			(xy 149.86 81.28) (xy 149.86 87.63)
 		)
 		(stroke
 			(width 0)
@@ -1092,7 +2102,7 @@
 	)
 	(wire
 		(pts
-			(xy 148.59 49.53) (xy 148.59 54.61)
+			(xy 196.85 60.96) (xy 196.85 66.04)
 		)
 		(stroke
 			(width 0)
@@ -1102,13 +2112,23 @@
 	)
 	(wire
 		(pts
-			(xy 140.97 105.41) (xy 146.05 105.41)
+			(xy 121.92 82.55) (xy 125.73 82.55)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "896dfffa-bb31-4656-9c25-c1d08e94de49")
+		(uuid "82879b8e-e1c2-4fa1-b772-6c32a9fb1515")
+	)
+	(wire
+		(pts
+			(xy 110.49 74.93) (xy 102.87 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "85d6b289-c01a-43a0-b8fb-a693135644aa")
 	)
 	(wire
 		(pts
@@ -1122,13 +2142,33 @@
 	)
 	(wire
 		(pts
-			(xy 125.73 97.79) (xy 125.73 105.41)
+			(xy 189.23 116.84) (xy 189.23 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ef81337-3c0d-421c-b71e-56ee1befb6af")
+	)
+	(wire
+		(pts
+			(xy 167.64 109.22) (xy 167.64 124.46)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "9b093f9b-346f-4ce0-8dd4-e5ee3e43cce5")
+	)
+	(wire
+		(pts
+			(xy 102.87 80.01) (xy 120.65 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a036df97-bcd1-4561-b913-a7b70e890dd5")
 	)
 	(wire
 		(pts
@@ -1142,7 +2182,17 @@
 	)
 	(wire
 		(pts
-			(xy 101.6 62.23) (xy 125.73 62.23)
+			(xy 167.64 109.22) (xy 173.99 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a993c6af-6101-4872-b9ed-49581335d58e")
+	)
+	(wire
+		(pts
+			(xy 149.86 73.66) (xy 173.99 73.66)
 		)
 		(stroke
 			(width 0)
@@ -1152,13 +2202,13 @@
 	)
 	(wire
 		(pts
-			(xy 140.97 105.41) (xy 140.97 111.76)
+			(xy 80.01 113.03) (xy 80.01 116.84)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c789bc7e-6645-48b6-8b16-76a61aa07d89")
+		(uuid "c848a625-cb59-4729-b612-72030ad6726d")
 	)
 	(polyline
 		(pts
@@ -1173,7 +2223,17 @@
 	)
 	(wire
 		(pts
-			(xy 146.05 105.41) (xy 148.59 105.41)
+			(xy 102.87 87.63) (xy 102.87 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dbf89de7-2c02-47a7-8923-24cf98ea91fd")
+	)
+	(wire
+		(pts
+			(xy 194.31 116.84) (xy 196.85 116.84)
 		)
 		(stroke
 			(width 0)
@@ -1183,28 +2243,87 @@
 	)
 	(wire
 		(pts
-			(xy 125.73 105.41) (xy 140.97 105.41)
+			(xy 102.87 88.9) (xy 102.87 90.17)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f3971de1-cf29-45cc-bfaa-6e41f89330a7")
+		(uuid "edfadf42-e0fc-4844-8a26-2f4c84f04824")
 	)
-	(hierarchical_label "USBD+"
-		(shape bidirectional)
-		(at 119.38 69.85 180)
+	(wire
+		(pts
+			(xy 102.87 92.71) (xy 102.87 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f953afcf-be9b-4ae7-a747-e49c8fb9a403")
+	)
+	(wire
+		(pts
+			(xy 87.63 113.03) (xy 87.63 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fba18a9c-d0de-4de3-817a-196796f86279")
+	)
+	(wire
+		(pts
+			(xy 128.27 80.01) (xy 132.08 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ff7a5c06-4a9c-4168-9c2b-8e3f5dfb770e")
+	)
+	(label "USBD+"
+		(at 110.49 88.9 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
-			(justify right)
+			(justify right bottom)
 		)
-		(uuid "2094b287-bb90-45b1-baad-25d54db5136b")
+		(uuid "26a746a3-750b-4cc6-9767-bd8c7172c191")
+	)
+	(label "USBD-"
+		(at 167.64 83.82 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "4083e950-aad2-4521-a4ac-b8521f65c8d6")
+	)
+	(label "USBD-"
+		(at 110.49 93.98 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "b7a1861c-e729-499f-a464-9da1ae688101")
+	)
+	(label "USBD+"
+		(at 167.64 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "dbf596a0-2f3c-4064-a3dd-4acbe3096cd4")
 	)
 	(hierarchical_label "3V3_VCC"
 		(shape input)
-		(at 143.51 48.26 90)
+		(at 191.77 59.69 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1213,9 +2332,9 @@
 		)
 		(uuid "3ffd6bca-4c91-423b-8fa7-7f4ca7ee9bbe")
 	)
-	(hierarchical_label "TXD"
+	(hierarchical_label "UART_TXD"
 		(shape bidirectional)
-		(at 172.72 62.23 0)
+		(at 220.98 73.66 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1224,19 +2343,8 @@
 		)
 		(uuid "7112fe62-6f9d-4ef5-a2bb-2a43f03cf5f7")
 	)
-	(hierarchical_label "USBD-"
-		(shape bidirectional)
-		(at 119.38 72.39 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "8fc3ca9e-06bb-46d8-8811-abe58b55c928")
-	)
 	(hierarchical_label "USB_VCC"
-		(shape input)
+		(shape output)
 		(at 24.13 35.56 180)
 		(effects
 			(font
@@ -1246,9 +2354,9 @@
 		)
 		(uuid "c6d0db75-de7f-4394-a203-3354e9d8054a")
 	)
-	(hierarchical_label "RXD"
+	(hierarchical_label "UART_RXD"
 		(shape bidirectional)
-		(at 172.72 64.77 0)
+		(at 220.98 76.2 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1258,8 +2366,75 @@
 		(uuid "d9e3a63f-de3c-4379-a102-4b09abf7cf24")
 	)
 	(symbol
+		(lib_id "Device:R")
+		(at 124.46 80.01 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0a7f8205-cb9b-4a21-b8ee-c32363a66fac")
+		(property "Reference" "R2"
+			(at 124.46 73.66 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 124.46 76.2 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 124.46 81.788 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 124.46 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 124.46 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "87060908-e108-4b57-b73b-9d0a6d5c50a3")
+		)
+		(pin "1"
+			(uuid "791db98f-63f8-41d0-ad0d-a4a071c56b75")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Interface_USB:FT232RL")
-		(at 146.05 80.01 0)
+		(at 194.31 91.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1268,7 +2443,7 @@
 		(fields_autoplaced yes)
 		(uuid "15c4b925-67bb-4e74-a707-79a35bc8a954")
 		(property "Reference" "U4"
-			(at 150.7333 53.34 0)
+			(at 198.9933 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1277,7 +2452,7 @@
 			)
 		)
 		(property "Value" "FT232RL"
-			(at 150.7333 55.88 0)
+			(at 198.9933 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1286,7 +2461,7 @@
 			)
 		)
 		(property "Footprint" "Package_SO:SSOP-28_5.3x10.2mm_P0.65mm"
-			(at 173.99 102.87 0)
+			(at 222.25 114.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1295,7 +2470,7 @@
 			)
 		)
 		(property "Datasheet" "https://ftdichip.com/wp-content/uploads/2020/08/DS_FT232R.pdf"
-			(at 146.05 80.01 0)
+			(at 194.31 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1304,7 +2479,7 @@
 			)
 		)
 		(property "Description" "USB to Serial Interface, SSOP-28"
-			(at 146.05 80.01 0)
+			(at 194.31 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1400,6 +2575,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 167.64 124.46 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1cb0a1b1-f558-4c78-95fd-682857754097")
+		(property "Reference" "#PWR032"
+			(at 167.64 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 167.64 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 167.64 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 167.64 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 167.64 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6f31c730-3d3d-42ab-ac24-914d5a5a6ba9")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR032")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:VCC")
 		(at 33.02 29.21 0)
 		(unit 1)
@@ -1466,17 +2707,17 @@
 		)
 	)
 	(symbol
-		(lib_id "power:VCC")
-		(at 148.59 49.53 0)
+		(lib_id "power:GND")
+		(at 125.73 85.09 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "7739b787-c7b0-40d2-af42-62bfaf27bf0b")
-		(property "Reference" "#PWR029"
-			(at 148.59 53.34 0)
+		(uuid "3f6bc562-9d34-4fa8-865b-42e3b6aab824")
+		(property "Reference" "#PWR024"
+			(at 125.73 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1484,8 +2725,8 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "VCC"
-			(at 148.59 44.45 0)
+		(property "Value" "GND"
+			(at 125.73 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1493,7 +2734,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 148.59 49.53 0)
+			(at 125.73 85.09 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1502,7 +2743,203 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 148.59 49.53 0)
+			(at 125.73 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 125.73 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "37bccff7-7dfc-42a3-adb6-2a526244f409")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR024")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 87.63 116.84 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4bbfee0f-4141-4876-a671-ada67be7a61f")
+		(property "Reference" "#PWR017"
+			(at 87.63 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 87.63 120.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 87.63 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 87.63 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 87.63 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f27a9e07-b846-48e0-a743-ba5cd2f761a4")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR017")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 132.08 85.09 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4bea2cdc-6222-49d7-ab9d-ee490ab17234")
+		(property "Reference" "#PWR023"
+			(at 132.08 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 132.08 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 132.08 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 132.08 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 132.08 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "34d5b0d5-98f1-4755-8241-a44351b4a7f1")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR023")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 196.85 60.96 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7739b787-c7b0-40d2-af42-62bfaf27bf0b")
+		(property "Reference" "#PWR029"
+			(at 196.85 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 196.85 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 196.85 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 196.85 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1511,7 +2948,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 148.59 49.53 0)
+			(at 196.85 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1533,7 +2970,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 101.6 76.2 0)
+		(at 149.86 87.63 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1542,7 +2979,7 @@
 		(fields_autoplaced yes)
 		(uuid "7abd2af0-feae-4957-9061-75c61bea0233")
 		(property "Reference" "#PWR025"
-			(at 101.6 82.55 0)
+			(at 149.86 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1551,7 +2988,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 101.6 81.28 0)
+			(at 149.86 92.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1559,7 +2996,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 101.6 76.2 0)
+			(at 149.86 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1568,7 +3005,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 101.6 76.2 0)
+			(at 149.86 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1577,7 +3014,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 101.6 76.2 0)
+			(at 149.86 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1598,26 +3035,26 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:C")
-		(at 101.6 66.04 0)
+		(lib_id "power:VCC")
+		(at 110.49 60.96 0)
+		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "bc8b059e-14e3-48a3-b08d-944f5a78758e")
-		(property "Reference" "C8"
-			(at 105.41 64.7699 0)
+		(uuid "95431191-2206-4610-a774-363f374a3fee")
+		(property "Reference" "#PWR026"
+			(at 110.49 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
+				(hide yes)
 			)
 		)
-		(property "Value" "100nF"
-			(at 105.41 67.3099 0)
+		(property "Value" "VCC"
+			(at 110.4901 57.15 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1626,7 +3063,139 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 102.5652 69.85 0)
+			(at 110.49 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 110.49 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1a1e30f7-3a95-4b00-9705-e791e02e9b43")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR026")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 80.01 116.84 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a7769180-8e10-4529-bf14-d18203bda983")
+		(property "Reference" "#PWR018"
+			(at 80.01 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 80.01 120.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 80.01 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 80.01 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 80.01 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5d39cffc-1c10-417d-9efc-f6d736acbb13")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR018")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 149.86 77.47 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bc8b059e-14e3-48a3-b08d-944f5a78758e")
+		(property "Reference" "C8"
+			(at 153.67 76.1999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 153.67 78.7399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 150.8252 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1635,7 +3204,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 101.6 66.04 0)
+			(at 149.86 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1644,7 +3213,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 101.6 66.04 0)
+			(at 149.86 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1668,8 +3237,188 @@
 		)
 	)
 	(symbol
+		(lib_id "Connector:USB_C_Receptacle_USB2.0_16P")
+		(at 87.63 90.17 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d87a5339-2bde-47bd-b2bd-8f67b44aefee")
+		(property "Reference" "J1"
+			(at 96.52 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "USB Type C Connector"
+			(at 100.33 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 91.44 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
+			(at 91.44 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "USB 2.0-only 16P Type-C Receptacle connector"
+			(at 87.63 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "B9"
+			(uuid "3f44cee3-52d1-432e-842a-97f265bce31c")
+		)
+		(pin "B1"
+			(uuid "bcecdc74-fce1-456f-bd54-40e0de593676")
+		)
+		(pin "A4"
+			(uuid "0c1c7f0d-b3fa-4e00-90c9-5d05459836e6")
+		)
+		(pin "B4"
+			(uuid "edea9345-dd3a-4fb2-8d14-af23759490fa")
+		)
+		(pin "A5"
+			(uuid "f2d42ad6-1b68-42de-a25c-9ce1c71ab218")
+		)
+		(pin "B8"
+			(uuid "34a8e103-76c0-4f93-b268-69ee3d4453dd")
+		)
+		(pin "B6"
+			(uuid "ccb525e3-3a81-4ff7-83c3-a0d992c8e790")
+		)
+		(pin "A12"
+			(uuid "cf76b54a-b705-4e47-8a9b-774b9b4dcc1c")
+		)
+		(pin "B12"
+			(uuid "7e325ae5-0902-43c9-bb07-f62ce914f832")
+		)
+		(pin "S1"
+			(uuid "4e889e66-924f-499d-b139-662ba7e3e042")
+		)
+		(pin "A1"
+			(uuid "a4f71d49-a38f-44f9-89c4-7ad64f7bbda2")
+		)
+		(pin "A7"
+			(uuid "08325ef9-b457-40ac-ac0e-3ab0b0b5d09f")
+		)
+		(pin "A9"
+			(uuid "0e1b8ce3-5550-41d5-8e01-ceb7b614293a")
+		)
+		(pin "B5"
+			(uuid "e4d650a2-5cb1-4bd0-94e6-3343292ff7b1")
+		)
+		(pin "B7"
+			(uuid "79b7dd5a-975e-4f63-b475-917ff704936d")
+		)
+		(pin "A6"
+			(uuid "c8ab5353-f0e4-482e-a057-fff97d69b56f")
+		)
+		(pin "A8"
+			(uuid "be7dae75-412b-48cc-bb57-d6944074dd95")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "J1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 118.11 82.55 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d9514cba-8fa6-455f-926e-02aa139d6616")
+		(property "Reference" "R3"
+			(at 118.11 88.9 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 118.11 86.36 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 118.11 80.772 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 118.11 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 118.11 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "106dcb14-7bf2-48c8-9061-ee2e0791d8d8")
+		)
+		(pin "2"
+			(uuid "8028f3f6-d79c-45a2-9402-316fffd4047c")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
-		(at 140.97 111.76 0)
+		(at 196.85 124.46 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1678,7 +3427,7 @@
 		(fields_autoplaced yes)
 		(uuid "e1399685-994c-44d8-8173-5fb6616101d6")
 		(property "Reference" "#PWR031"
-			(at 140.97 118.11 0)
+			(at 196.85 130.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1687,7 +3436,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 140.97 116.84 0)
+			(at 196.85 129.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1695,7 +3444,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 140.97 111.76 0)
+			(at 196.85 124.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1704,7 +3453,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 140.97 111.76 0)
+			(at 196.85 124.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1713,7 +3462,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 140.97 111.76 0)
+			(at 196.85 124.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1728,6 +3477,72 @@
 			(project ""
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "#PWR031")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GNDA")
+		(at 189.23 124.46 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fed10362-c97d-4e00-a755-50e4de9b13f9")
+		(property "Reference" "#PWR033"
+			(at 189.23 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GNDA"
+			(at 189.23 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 189.23 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 189.23 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
+			(at 189.23 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "040e17e2-7a59-4f4c-b631-214f134273c4")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR033")
 					(unit 1)
 				)
 			)

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -1857,13 +1857,27 @@
 		)
 		(uuid "15d99aca-2331-4f4c-a326-4061af767c08")
 	)
+	(text "Reset In\n"
+		(exclude_from_sim no)
+		(at 51.562 17.526 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "be062ef9-aa9f-49b2-9628-171edf3f9a2c")
+	)
 	(text "Power Out\n"
 		(exclude_from_sim no)
 		(at 18.542 17.018 0)
 		(effects
 			(font
 				(size 1.27 1.27)
-				(thickness 0.1588)
+				(thickness 0.254)
+				(bold yes)
 				(color 0 0 0 1)
 			)
 		)
@@ -1930,10 +1944,6 @@
 	(no_connect
 		(at 173.99 96.52)
 		(uuid "ce1c43fe-49fe-4733-9524-b8a94dbf15fb")
-	)
-	(no_connect
-		(at 173.99 91.44)
-		(uuid "d2fa6037-2b7d-4e48-9b25-91c295893506")
 	)
 	(no_connect
 		(at 102.87 102.87)
@@ -2102,6 +2112,17 @@
 		)
 		(uuid "7219083e-22c4-47db-97ca-462a0c85a00e")
 	)
+	(polyline
+		(pts
+			(xy 64.77 39.37) (xy 64.77 12.7)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "761eb2cb-76e4-44f7-8c80-9b59f2358bf4")
+	)
 	(wire
 		(pts
 			(xy 196.85 60.96) (xy 196.85 66.04)
@@ -2145,6 +2166,16 @@
 	)
 	(wire
 		(pts
+			(xy 58.42 35.56) (xy 49.53 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ee4b1c2-dd11-4dfc-907b-5ef8dc740c91")
+	)
+	(wire
+		(pts
 			(xy 189.23 116.84) (xy 189.23 124.46)
 		)
 		(stroke
@@ -2182,6 +2213,16 @@
 			(type default)
 		)
 		(uuid "a2821313-c254-49c0-a6f5-721f0268bfc4")
+	)
+	(wire
+		(pts
+			(xy 58.42 25.4) (xy 58.42 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a68192aa-56b3-4937-bd18-60f2777d33ae")
 	)
 	(wire
 		(pts
@@ -2274,6 +2315,17 @@
 		)
 		(uuid "e44c1e04-3961-447b-afa1-8fe962ef4ec1")
 	)
+	(polyline
+		(pts
+			(xy 38.1 39.37) (xy 64.77 39.37)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "e7665f2f-3400-452e-8ce9-2c02d43ef6ad")
+	)
 	(wire
 		(pts
 			(xy 102.87 88.9) (xy 102.87 90.17)
@@ -2315,6 +2367,16 @@
 		)
 		(uuid "fba18a9c-d0de-4de3-817a-196796f86279")
 	)
+	(wire
+		(pts
+			(xy 167.64 91.44) (xy 173.99 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fbcfa7a0-4acd-4856-99b5-0ad2017a9ed0")
+	)
 	(label "CC2"
 		(at 274.32 16.51 0)
 		(effects
@@ -2354,6 +2416,16 @@
 			(justify right bottom)
 		)
 		(uuid "4083e950-aad2-4521-a4ac-b8521f65c8d6")
+	)
+	(label "RESET"
+		(at 58.42 25.4 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "7e41ab32-921d-4297-865b-b2b58cbc189e")
 	)
 	(label "CC1"
 		(at 256.54 16.51 0)
@@ -2395,6 +2467,16 @@
 		)
 		(uuid "dbf596a0-2f3c-4064-a3dd-4acbe3096cd4")
 	)
+	(label "RESET"
+		(at 167.64 91.44 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "ecdaef53-1c8f-469b-a200-8bbb172a16bb")
+	)
 	(hierarchical_label "3V3_VCC"
 		(shape input)
 		(at 191.77 59.69 90)
@@ -2416,6 +2498,17 @@
 			(justify left)
 		)
 		(uuid "7112fe62-6f9d-4ef5-a2bb-2a43f03cf5f7")
+	)
+	(hierarchical_label "RESET"
+		(shape input)
+		(at 49.53 35.56 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a614b151-2071-4746-878c-31aebcd12102")
 	)
 	(hierarchical_label "USB_VCC"
 		(shape output)

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -2530,7 +2530,7 @@
 				)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
 			(at 276.098 25.4 90)
 			(effects
 				(font
@@ -2871,7 +2871,7 @@
 				)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
 			(at 258.318 25.4 90)
 			(effects
 				(font
@@ -3336,7 +3336,7 @@
 				(justify left)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
 			(at 150.8252 81.28 0)
 			(effects
 				(font

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -841,6 +841,189 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "Device:LED"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Device:R"
 			(pin_numbers
 				(hide yes)
@@ -1847,7 +2030,7 @@
 	)
 	(text "Reference: Chapter 3.2 of datasheet"
 		(exclude_from_sim no)
-		(at 247.142 41.402 0)
+		(at 247.396 50.546 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1856,6 +2039,45 @@
 			(justify left)
 		)
 		(uuid "15d99aca-2331-4f4c-a326-4061af767c08")
+	)
+	(text "TX Led"
+		(exclude_from_sim no)
+		(at 192.024 50.546 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "3568bc9c-42c1-41a3-a266-c2918c406116")
+	)
+	(text "Power Led"
+		(exclude_from_sim no)
+		(at 229.616 50.546 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "439ac335-b5cf-4728-901b-66d196b74c4f")
+	)
+	(text "RX Led"
+		(exclude_from_sim no)
+		(at 211.074 50.546 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "9a8debe4-39bc-44c5-8724-9a582d6e3bac")
 	)
 	(text "Reset In\n"
 		(exclude_from_sim no)
@@ -1884,86 +2106,78 @@
 		(uuid "c95dae2c-3365-451e-a5a9-c01d62a8daab")
 	)
 	(junction
-		(at 102.87 93.98)
+		(at 110.49 111.76)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "3400ef6b-ed27-498b-b1cb-69fad5c36855")
 	)
 	(junction
-		(at 102.87 88.9)
+		(at 110.49 106.68)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "6bf1c60a-15e8-44c7-8d7f-770e0fd62223")
 	)
 	(junction
-		(at 196.85 116.84)
+		(at 204.47 134.62)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "ef8f5390-5bab-4421-a2c4-421a0cf5a7ef")
 	)
 	(no_connect
-		(at 214.63 83.82)
+		(at 222.25 101.6)
 		(uuid "517e1990-205b-45e1-86c1-ba379163f2ab")
 	)
 	(no_connect
-		(at 102.87 105.41)
+		(at 110.49 123.19)
 		(uuid "8f7c58fa-8ada-4ae6-b8df-6fdfdce6c7d9")
 	)
 	(no_connect
-		(at 214.63 106.68)
+		(at 222.25 124.46)
 		(uuid "8fae41a0-0e47-41d7-9422-25263397e7e7")
 	)
 	(no_connect
-		(at 173.99 101.6)
+		(at 181.61 119.38)
 		(uuid "9be4298f-6fb6-4efd-b86e-51ac092eb9f7")
 	)
 	(no_connect
-		(at 214.63 88.9)
+		(at 222.25 106.68)
 		(uuid "a0b023d3-ef01-4828-806e-30f6f31a5b41")
 	)
 	(no_connect
-		(at 214.63 99.06)
-		(uuid "ac653252-6bd7-4084-b413-d8ff41adb071")
-	)
-	(no_connect
-		(at 214.63 81.28)
+		(at 222.25 99.06)
 		(uuid "ad748d64-dbe4-4dba-bb38-04d415cd6964")
 	)
 	(no_connect
-		(at 214.63 101.6)
-		(uuid "af5f79da-93b2-404c-878b-97703347a6b4")
-	)
-	(no_connect
-		(at 214.63 86.36)
+		(at 222.25 104.14)
 		(uuid "b6afa0c8-9acc-43f8-96f9-c65cf4252a57")
 	)
 	(no_connect
-		(at 214.63 91.44)
+		(at 222.25 109.22)
 		(uuid "bd7f7341-8760-47fb-ad7d-362895cbef2b")
 	)
 	(no_connect
-		(at 173.99 96.52)
+		(at 181.61 114.3)
 		(uuid "ce1c43fe-49fe-4733-9524-b8a94dbf15fb")
 	)
 	(no_connect
-		(at 102.87 102.87)
+		(at 110.49 120.65)
 		(uuid "db76a7a5-23d9-4668-80a8-72bff9143d8b")
 	)
 	(no_connect
-		(at 214.63 109.22)
+		(at 222.25 127)
 		(uuid "e53bb683-7eb9-4998-b51b-c90fa818d7db")
 	)
 	(no_connect
-		(at 214.63 78.74)
+		(at 222.25 96.52)
 		(uuid "f06ebede-3bff-43ce-829a-3d61417c8ae8")
 	)
 	(no_connect
-		(at 214.63 104.14)
+		(at 222.25 121.92)
 		(uuid "f512327e-0d35-4b5c-8c1a-fafb6bc3a42c")
 	)
 	(wire
 		(pts
-			(xy 102.87 88.9) (xy 110.49 88.9)
+			(xy 110.49 106.68) (xy 118.11 106.68)
 		)
 		(stroke
 			(width 0)
@@ -1973,7 +2187,7 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 60.96) (xy 110.49 74.93)
+			(xy 118.11 78.74) (xy 118.11 92.71)
 		)
 		(stroke
 			(width 0)
@@ -1983,7 +2197,17 @@
 	)
 	(wire
 		(pts
-			(xy 196.85 116.84) (xy 199.39 116.84)
+			(xy 222.25 116.84) (xy 228.6 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1dad0933-cfef-484e-a406-aa96f1d842d0")
+	)
+	(wire
+		(pts
+			(xy 204.47 134.62) (xy 207.01 134.62)
 		)
 		(stroke
 			(width 0)
@@ -1993,7 +2217,7 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 93.98) (xy 110.49 93.98)
+			(xy 110.49 111.76) (xy 118.11 111.76)
 		)
 		(stroke
 			(width 0)
@@ -2003,7 +2227,7 @@
 	)
 	(wire
 		(pts
-			(xy 196.85 116.84) (xy 196.85 124.46)
+			(xy 204.47 134.62) (xy 204.47 142.24)
 		)
 		(stroke
 			(width 0)
@@ -2013,7 +2237,7 @@
 	)
 	(wire
 		(pts
-			(xy 167.64 83.82) (xy 173.99 83.82)
+			(xy 175.26 101.6) (xy 181.61 101.6)
 		)
 		(stroke
 			(width 0)
@@ -2021,9 +2245,30 @@
 		)
 		(uuid "39663861-680f-4c75-972b-6cf7d46ba0fb")
 	)
+	(polyline
+		(pts
+			(xy 185.42 12.7) (xy 185.42 52.07)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "4f3eb793-4ec9-4b15-8e57-8983829f4386")
+	)
 	(wire
 		(pts
-			(xy 102.87 93.98) (xy 102.87 95.25)
+			(xy 190.5 20.32) (xy 190.5 22.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "547b081a-f5b5-4cb7-b5c1-1801c9957f57")
+	)
+	(wire
+		(pts
+			(xy 110.49 111.76) (xy 110.49 113.03)
 		)
 		(stroke
 			(width 0)
@@ -2033,7 +2278,17 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 82.55) (xy 110.49 82.55)
+			(xy 209.55 30.48) (xy 209.55 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a2d5fe1-5807-4d3a-b9fb-42692e4ffb5c")
+	)
+	(wire
+		(pts
+			(xy 110.49 100.33) (xy 118.11 100.33)
 		)
 		(stroke
 			(width 0)
@@ -2043,7 +2298,7 @@
 	)
 	(wire
 		(pts
-			(xy 214.63 76.2) (xy 220.98 76.2)
+			(xy 222.25 93.98) (xy 228.6 93.98)
 		)
 		(stroke
 			(width 0)
@@ -2053,7 +2308,7 @@
 	)
 	(wire
 		(pts
-			(xy 167.64 81.28) (xy 173.99 81.28)
+			(xy 175.26 99.06) (xy 181.61 99.06)
 		)
 		(stroke
 			(width 0)
@@ -2063,7 +2318,7 @@
 	)
 	(wire
 		(pts
-			(xy 191.77 59.69) (xy 191.77 66.04)
+			(xy 199.39 77.47) (xy 199.39 83.82)
 		)
 		(stroke
 			(width 0)
@@ -2073,7 +2328,7 @@
 	)
 	(wire
 		(pts
-			(xy 214.63 73.66) (xy 220.98 73.66)
+			(xy 222.25 91.44) (xy 228.6 91.44)
 		)
 		(stroke
 			(width 0)
@@ -2083,17 +2338,27 @@
 	)
 	(wire
 		(pts
-			(xy 274.32 29.21) (xy 274.32 31.75)
+			(xy 190.5 40.64) (xy 190.5 46.99)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "7184cca3-6781-45b0-afae-9cc2e11d6b2f")
+		(uuid "6ac4bb52-f2b7-41fe-af8d-f1e9197982de")
 	)
 	(wire
 		(pts
-			(xy 149.86 81.28) (xy 149.86 87.63)
+			(xy 209.55 20.32) (xy 209.55 22.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6dc3124e-836f-4635-925e-20847a1e4294")
+	)
+	(wire
+		(pts
+			(xy 157.48 99.06) (xy 157.48 105.41)
 		)
 		(stroke
 			(width 0)
@@ -2125,7 +2390,7 @@
 	)
 	(wire
 		(pts
-			(xy 196.85 60.96) (xy 196.85 66.04)
+			(xy 204.47 78.74) (xy 204.47 83.82)
 		)
 		(stroke
 			(width 0)
@@ -2135,7 +2400,17 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 74.93) (xy 102.87 74.93)
+			(xy 209.55 40.64) (xy 209.55 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83dc6c8e-4814-4201-9b9c-475b93ff270e")
+	)
+	(wire
+		(pts
+			(xy 118.11 92.71) (xy 110.49 92.71)
 		)
 		(stroke
 			(width 0)
@@ -2145,7 +2420,7 @@
 	)
 	(polyline
 		(pts
-			(xy 284.48 43.18) (xy 245.11 43.18)
+			(xy 284.48 52.07) (xy 242.57 52.07)
 		)
 		(stroke
 			(width 0)
@@ -2164,6 +2439,17 @@
 		)
 		(uuid "8a4aa539-9a86-4c51-bf8d-bfc3e13fe88b")
 	)
+	(polyline
+		(pts
+			(xy 242.57 52.07) (xy 185.42 52.07)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "8bd06b60-4c95-47ba-b7d3-16cf597e9d35")
+	)
 	(wire
 		(pts
 			(xy 58.42 35.56) (xy 49.53 35.56)
@@ -2176,7 +2462,7 @@
 	)
 	(wire
 		(pts
-			(xy 189.23 116.84) (xy 189.23 124.46)
+			(xy 196.85 134.62) (xy 196.85 142.24)
 		)
 		(stroke
 			(width 0)
@@ -2186,23 +2472,23 @@
 	)
 	(wire
 		(pts
-			(xy 256.54 29.21) (xy 256.54 31.75)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "923d994b-c738-480b-ab05-d0f08207a8a9")
-	)
-	(wire
-		(pts
-			(xy 167.64 109.22) (xy 167.64 124.46)
+			(xy 175.26 127) (xy 175.26 142.24)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "9b093f9b-346f-4ce0-8dd4-e5ee3e43cce5")
+	)
+	(wire
+		(pts
+			(xy 222.25 119.38) (xy 228.6 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9ed498ba-c903-4cf0-b46e-31f37cf016d9")
 	)
 	(wire
 		(pts
@@ -2226,7 +2512,7 @@
 	)
 	(wire
 		(pts
-			(xy 167.64 109.22) (xy 173.99 109.22)
+			(xy 175.26 127) (xy 181.61 127)
 		)
 		(stroke
 			(width 0)
@@ -2236,7 +2522,7 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 73.66) (xy 173.99 73.66)
+			(xy 157.48 91.44) (xy 181.61 91.44)
 		)
 		(stroke
 			(width 0)
@@ -2246,7 +2532,7 @@
 	)
 	(wire
 		(pts
-			(xy 256.54 16.51) (xy 256.54 21.59)
+			(xy 256.54 16.51) (xy 256.54 33.02)
 		)
 		(stroke
 			(width 0)
@@ -2256,13 +2542,23 @@
 	)
 	(wire
 		(pts
-			(xy 80.01 113.03) (xy 80.01 116.84)
+			(xy 87.63 130.81) (xy 87.63 134.62)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "c848a625-cb59-4729-b612-72030ad6726d")
+	)
+	(wire
+		(pts
+			(xy 190.5 30.48) (xy 190.5 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c88a1b1d-b46b-441c-b584-d2685adf3ff4")
 	)
 	(polyline
 		(pts
@@ -2277,7 +2573,17 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 87.63) (xy 102.87 88.9)
+			(xy 228.6 30.48) (xy 228.6 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6a7c58d-6162-4f76-9055-5aa947c2cc51")
+	)
+	(wire
+		(pts
+			(xy 110.49 105.41) (xy 110.49 106.68)
 		)
 		(stroke
 			(width 0)
@@ -2287,7 +2593,7 @@
 	)
 	(wire
 		(pts
-			(xy 194.31 116.84) (xy 196.85 116.84)
+			(xy 201.93 134.62) (xy 204.47 134.62)
 		)
 		(stroke
 			(width 0)
@@ -2297,7 +2603,7 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 80.01) (xy 110.49 80.01)
+			(xy 110.49 97.79) (xy 118.11 97.79)
 		)
 		(stroke
 			(width 0)
@@ -2307,7 +2613,7 @@
 	)
 	(wire
 		(pts
-			(xy 274.32 16.51) (xy 274.32 21.59)
+			(xy 274.32 16.51) (xy 274.32 33.02)
 		)
 		(stroke
 			(width 0)
@@ -2328,7 +2634,7 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 88.9) (xy 102.87 90.17)
+			(xy 110.49 106.68) (xy 110.49 107.95)
 		)
 		(stroke
 			(width 0)
@@ -2338,7 +2644,17 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 92.71) (xy 102.87 93.98)
+			(xy 228.6 20.32) (xy 228.6 22.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f030e099-eb2c-4416-983b-4bfe66dcef85")
+	)
+	(wire
+		(pts
+			(xy 110.49 110.49) (xy 110.49 111.76)
 		)
 		(stroke
 			(width 0)
@@ -2348,7 +2664,7 @@
 	)
 	(polyline
 		(pts
-			(xy 245.11 43.18) (xy 245.11 12.7)
+			(xy 242.57 52.07) (xy 242.57 12.7)
 		)
 		(stroke
 			(width 0)
@@ -2359,7 +2675,7 @@
 	)
 	(wire
 		(pts
-			(xy 87.63 113.03) (xy 87.63 116.84)
+			(xy 95.25 130.81) (xy 95.25 134.62)
 		)
 		(stroke
 			(width 0)
@@ -2369,7 +2685,7 @@
 	)
 	(wire
 		(pts
-			(xy 167.64 91.44) (xy 173.99 91.44)
+			(xy 175.26 109.22) (xy 181.61 109.22)
 		)
 		(stroke
 			(width 0)
@@ -2388,7 +2704,7 @@
 		(uuid "258bf8e1-2933-433e-a0cf-64b0c3ccfce9")
 	)
 	(label "USBD+"
-		(at 110.49 88.9 180)
+		(at 118.11 106.68 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2398,7 +2714,7 @@
 		(uuid "26a746a3-750b-4cc6-9767-bd8c7172c191")
 	)
 	(label "CC1"
-		(at 110.49 80.01 180)
+		(at 118.11 97.79 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2408,7 +2724,7 @@
 		(uuid "310fe3b4-3e03-42a6-82f9-ca9749fa7d99")
 	)
 	(label "USBD-"
-		(at 167.64 83.82 180)
+		(at 175.26 101.6 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2416,6 +2732,16 @@
 			(justify right bottom)
 		)
 		(uuid "4083e950-aad2-4521-a4ac-b8521f65c8d6")
+	)
+	(label "RXLED"
+		(at 228.6 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5ff73537-762a-43ea-988a-f129b6e11520")
 	)
 	(label "RESET"
 		(at 58.42 25.4 180)
@@ -2438,7 +2764,7 @@
 		(uuid "a641cc17-7d4f-4b0b-b4b8-10aaea87dc55")
 	)
 	(label "USBD-"
-		(at 110.49 93.98 180)
+		(at 118.11 111.76 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2448,7 +2774,7 @@
 		(uuid "b7a1861c-e729-499f-a464-9da1ae688101")
 	)
 	(label "CC2"
-		(at 110.49 82.55 180)
+		(at 118.11 100.33 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2457,8 +2783,28 @@
 		)
 		(uuid "c52d0131-fcfd-48cb-b663-4a5d112b4d1e")
 	)
+	(label "TXLED"
+		(at 209.55 46.99 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d8b19657-d895-4e57-bc1a-7e3d41b3d120")
+	)
+	(label "TXLED"
+		(at 228.6 116.84 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "db5412c3-b9e6-4a52-a084-7eacf83c4b14")
+	)
 	(label "USBD+"
-		(at 167.64 81.28 180)
+		(at 175.26 99.06 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2467,8 +2813,18 @@
 		)
 		(uuid "dbf596a0-2f3c-4064-a3dd-4acbe3096cd4")
 	)
+	(label "RXLED"
+		(at 190.5 46.99 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "e32bd2b0-543f-431b-a699-8633f60f9709")
+	)
 	(label "RESET"
-		(at 167.64 91.44 180)
+		(at 175.26 109.22 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2479,7 +2835,7 @@
 	)
 	(hierarchical_label "3V3_VCC"
 		(shape input)
-		(at 191.77 59.69 90)
+		(at 199.39 77.47 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2490,7 +2846,7 @@
 	)
 	(hierarchical_label "UART_TXD"
 		(shape output)
-		(at 220.98 73.66 0)
+		(at 228.6 91.44 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2523,7 +2879,7 @@
 	)
 	(hierarchical_label "UART_RXD"
 		(shape input)
-		(at 220.98 76.2 0)
+		(at 228.6 93.98 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2534,7 +2890,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 274.32 31.75 0)
+		(at 274.32 40.64 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2543,7 +2899,7 @@
 		(fields_autoplaced yes)
 		(uuid "0d167cf5-c721-4d62-b48e-35cf1dec132e")
 		(property "Reference" "#PWR035"
-			(at 274.32 38.1 0)
+			(at 274.32 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2552,7 +2908,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 274.32 36.83 0)
+			(at 274.32 45.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2560,7 +2916,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 274.32 31.75 0)
+			(at 274.32 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2569,7 +2925,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 274.32 31.75 0)
+			(at 274.32 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2578,7 +2934,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 274.32 31.75 0)
+			(at 274.32 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2600,7 +2956,7 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 274.32 25.4 180)
+		(at 274.32 36.83 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2608,7 +2964,7 @@
 		(dnp no)
 		(uuid "0d308bd9-cecb-48ef-b4f2-fa875fc0a3c5")
 		(property "Reference" "R5"
-			(at 267.97 25.4 90)
+			(at 267.97 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2616,7 +2972,7 @@
 			)
 		)
 		(property "Value" "5.1k"
-			(at 270.51 25.4 90)
+			(at 270.51 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2624,7 +2980,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 276.098 25.4 90)
+			(at 276.098 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2633,7 +2989,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 274.32 25.4 0)
+			(at 274.32 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2642,7 +2998,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 274.32 25.4 0)
+			(at 274.32 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2667,7 +3023,7 @@
 	)
 	(symbol
 		(lib_id "Interface_USB:FT232RL")
-		(at 194.31 91.44 0)
+		(at 201.93 109.22 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2676,7 +3032,7 @@
 		(fields_autoplaced yes)
 		(uuid "15c4b925-67bb-4e74-a707-79a35bc8a954")
 		(property "Reference" "U4"
-			(at 198.9933 64.77 0)
+			(at 206.6133 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2685,7 +3041,7 @@
 			)
 		)
 		(property "Value" "FT232RL"
-			(at 198.9933 67.31 0)
+			(at 206.6133 85.09 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2694,7 +3050,7 @@
 			)
 		)
 		(property "Footprint" "Package_SO:SSOP-28_5.3x10.2mm_P0.65mm"
-			(at 222.25 114.3 0)
+			(at 229.87 132.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2703,7 +3059,7 @@
 			)
 		)
 		(property "Datasheet" "https://ftdichip.com/wp-content/uploads/2020/08/DS_FT232R.pdf"
-			(at 194.31 91.44 0)
+			(at 201.93 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2712,7 +3068,7 @@
 			)
 		)
 		(property "Description" "USB to Serial Interface, SSOP-28"
-			(at 194.31 91.44 0)
+			(at 201.93 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2809,7 +3165,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 167.64 124.46 0)
+		(at 175.26 142.24 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2818,7 +3174,7 @@
 		(fields_autoplaced yes)
 		(uuid "1cb0a1b1-f558-4c78-95fd-682857754097")
 		(property "Reference" "#PWR032"
-			(at 167.64 130.81 0)
+			(at 175.26 148.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2827,7 +3183,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 167.64 129.54 0)
+			(at 175.26 147.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2835,7 +3191,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 167.64 124.46 0)
+			(at 175.26 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2844,7 +3200,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 167.64 124.46 0)
+			(at 175.26 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2853,7 +3209,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 167.64 124.46 0)
+			(at 175.26 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2868,6 +3224,85 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "#PWR032")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 209.55 26.67 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2e47384f-0bba-4939-aebb-7bc9de30fd48")
+		(property "Reference" "D3"
+			(at 213.36 26.9874 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED"
+			(at 213.36 29.5274 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" ""
+			(at 209.55 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 209.55 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 209.55 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 209.55 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "011bfe33-0770-4ddb-b0da-b6840b06eefc")
+		)
+		(pin "2"
+			(uuid "68c16ed6-10cc-446d-8c7a-763c251c8d65")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "D3")
 					(unit 1)
 				)
 			)
@@ -2941,7 +3376,7 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 256.54 25.4 180)
+		(at 256.54 36.83 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2949,7 +3384,7 @@
 		(dnp no)
 		(uuid "342aeb10-0bfd-45a0-a129-74967514fbf4")
 		(property "Reference" "R4"
-			(at 250.19 25.4 90)
+			(at 250.19 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2957,7 +3392,7 @@
 			)
 		)
 		(property "Value" "5.1k"
-			(at 252.73 25.4 90)
+			(at 252.73 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2965,7 +3400,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 258.318 25.4 90)
+			(at 258.318 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2974,7 +3409,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 256.54 25.4 0)
+			(at 256.54 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2983,7 +3418,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 256.54 25.4 0)
+			(at 256.54 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3008,7 +3443,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 256.54 31.75 0)
+		(at 256.54 40.64 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3017,7 +3452,7 @@
 		(fields_autoplaced yes)
 		(uuid "3fc5b8d7-c07b-4c23-a54c-53bc69f574f4")
 		(property "Reference" "#PWR034"
-			(at 256.54 38.1 0)
+			(at 256.54 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3026,7 +3461,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 256.54 36.83 0)
+			(at 256.54 45.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3034,7 +3469,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 256.54 31.75 0)
+			(at 256.54 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3043,7 +3478,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 256.54 31.75 0)
+			(at 256.54 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3052,7 +3487,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 256.54 31.75 0)
+			(at 256.54 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3074,7 +3509,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 87.63 116.84 0)
+		(at 95.25 134.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3082,7 +3517,7 @@
 		(dnp no)
 		(uuid "4bbfee0f-4141-4876-a671-ada67be7a61f")
 		(property "Reference" "#PWR017"
-			(at 87.63 123.19 0)
+			(at 95.25 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3091,7 +3526,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 87.63 120.65 0)
+			(at 95.25 138.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3099,7 +3534,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 87.63 116.84 0)
+			(at 95.25 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3108,7 +3543,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 87.63 116.84 0)
+			(at 95.25 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3117,7 +3552,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 87.63 116.84 0)
+			(at 95.25 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3138,8 +3573,78 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R")
+		(at 228.6 36.83 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6ef5e22b-684c-40d3-ad48-28b36b75217f")
+		(property "Reference" "R2"
+			(at 231.14 35.5599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "150"
+			(at 231.14 38.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 226.822 36.83 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 228.6 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 228.6 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "00aec166-b44a-476e-aa32-6b8f69e4252a")
+		)
+		(pin "2"
+			(uuid "ad2c462a-3611-4a44-8ece-a40ff1515599")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:VCC")
-		(at 196.85 60.96 0)
+		(at 204.47 78.74 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3148,7 +3653,7 @@
 		(fields_autoplaced yes)
 		(uuid "7739b787-c7b0-40d2-af42-62bfaf27bf0b")
 		(property "Reference" "#PWR029"
-			(at 196.85 64.77 0)
+			(at 204.47 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3157,7 +3662,7 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 196.85 55.88 0)
+			(at 204.47 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3165,7 +3670,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 196.85 60.96 0)
+			(at 204.47 78.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3174,7 +3679,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 196.85 60.96 0)
+			(at 204.47 78.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3183,7 +3688,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 196.85 60.96 0)
+			(at 204.47 78.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3205,16 +3710,16 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 149.86 87.63 0)
+		(at 228.6 40.64 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "7abd2af0-feae-4957-9061-75c61bea0233")
-		(property "Reference" "#PWR025"
-			(at 149.86 93.98 0)
+		(uuid "7a12e358-f1ac-4e45-9814-23b17c7b000c")
+		(property "Reference" "#PWR037"
+			(at 228.6 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3223,7 +3728,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 149.86 92.71 0)
+			(at 228.6 45.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3231,7 +3736,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 149.86 87.63 0)
+			(at 228.6 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3240,7 +3745,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 149.86 87.63 0)
+			(at 228.6 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3249,7 +3754,73 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 149.86 87.63 0)
+			(at 228.6 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c953ce9-fec8-4fa7-a538-fe9d6ae6e943")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR037")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 157.48 105.41 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7abd2af0-feae-4957-9061-75c61bea0233")
+		(property "Reference" "#PWR025"
+			(at 157.48 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 157.48 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 157.48 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 157.48 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 157.48 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3271,16 +3842,16 @@
 	)
 	(symbol
 		(lib_id "power:VCC")
-		(at 110.49 60.96 0)
-		(mirror y)
+		(at 228.6 20.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "95431191-2206-4610-a774-363f374a3fee")
-		(property "Reference" "#PWR026"
-			(at 110.49 64.77 0)
+		(fields_autoplaced yes)
+		(uuid "7bccaa12-18a5-493a-b57d-f2677039ae8f")
+		(property "Reference" "#PWR036"
+			(at 228.6 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3289,16 +3860,15 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 110.4901 57.15 90)
+			(at 228.6 15.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
 			)
 		)
 		(property "Footprint" ""
-			(at 110.49 60.96 0)
+			(at 228.6 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3307,7 +3877,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 110.49 60.96 0)
+			(at 228.6 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3316,7 +3886,372 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 110.49 60.96 0)
+			(at 228.6 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0fc2d4c3-78cd-404d-a181-806efd6c0493")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR036")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 228.6 26.67 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8455eb92-9069-472e-b8d2-0ed3600c79d7")
+		(property "Reference" "D1"
+			(at 232.41 26.9874 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED"
+			(at 232.41 29.5274 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" ""
+			(at 228.6 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 228.6 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 228.6 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 228.6 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc22c2de-5f07-4dae-8807-9f1ff152e06f")
+		)
+		(pin "2"
+			(uuid "e94d2bb0-4949-4e7b-b242-7776163ff4c6")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 190.5 36.83 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "89451875-5cdb-4488-8520-6e09b8f34260")
+		(property "Reference" "R3"
+			(at 193.04 35.5599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "150"
+			(at 193.04 38.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 188.722 36.83 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 190.5 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 190.5 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4b68a104-2d39-44b1-bb67-531b496ce58b")
+		)
+		(pin "2"
+			(uuid "0174547b-11b2-4bb8-b04f-c6713501fc95")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 209.55 36.83 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9483813b-1772-4181-ba5c-d300c40bf602")
+		(property "Reference" "R6"
+			(at 212.09 35.5599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "150"
+			(at 212.09 38.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 207.772 36.83 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 209.55 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 209.55 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a6428db5-f8c7-4950-917d-4dc6aeddf6e8")
+		)
+		(pin "2"
+			(uuid "015cca02-9ae2-4bae-b4bf-65aa6c08c980")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "R6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 190.5 26.67 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "94ee5ef2-5a94-4903-bb92-702739feef33")
+		(property "Reference" "D2"
+			(at 194.31 26.9874 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED"
+			(at 194.31 29.5274 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" ""
+			(at 190.5 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 190.5 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 190.5 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 190.5 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df9bfe16-2304-4cb4-b9ba-a4538ae78a68")
+		)
+		(pin "2"
+			(uuid "6a22a590-6a87-4609-9d1e-3f5056f18f19")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 118.11 78.74 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "95431191-2206-4610-a774-363f374a3fee")
+		(property "Reference" "#PWR026"
+			(at 118.11 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 118.1101 74.93 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 118.11 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 118.11 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 118.11 78.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3338,7 +4273,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 80.01 116.84 0)
+		(at 87.63 134.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3346,7 +4281,7 @@
 		(dnp no)
 		(uuid "a7769180-8e10-4529-bf14-d18203bda983")
 		(property "Reference" "#PWR018"
-			(at 80.01 123.19 0)
+			(at 87.63 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3355,7 +4290,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 80.01 120.65 0)
+			(at 87.63 138.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3363,7 +4298,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 80.01 116.84 0)
+			(at 87.63 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3372,7 +4307,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 80.01 116.84 0)
+			(at 87.63 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3381,7 +4316,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 80.01 116.84 0)
+			(at 87.63 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3403,7 +4338,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 149.86 77.47 0)
+		(at 157.48 95.25 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3412,7 +4347,7 @@
 		(fields_autoplaced yes)
 		(uuid "bc8b059e-14e3-48a3-b08d-944f5a78758e")
 		(property "Reference" "C8"
-			(at 153.67 76.1999 0)
+			(at 161.29 93.9799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3421,7 +4356,7 @@
 			)
 		)
 		(property "Value" "100nF"
-			(at 153.67 78.7399 0)
+			(at 161.29 96.5199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3430,7 +4365,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 150.8252 81.28 0)
+			(at 158.4452 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3439,7 +4374,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 149.86 77.47 0)
+			(at 157.48 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3448,7 +4383,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 149.86 77.47 0)
+			(at 157.48 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3472,24 +4407,26 @@
 		)
 	)
 	(symbol
-		(lib_id "Connector:USB_C_Receptacle_USB2.0_16P")
-		(at 87.63 90.17 0)
+		(lib_id "power:VCC")
+		(at 209.55 20.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "d87a5339-2bde-47bd-b2bd-8f67b44aefee")
-		(property "Reference" "J1"
-			(at 96.52 69.85 0)
+		(fields_autoplaced yes)
+		(uuid "c9005292-8e8f-45de-90b9-1b291032a771")
+		(property "Reference" "#PWR040"
+			(at 209.55 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(hide yes)
 			)
 		)
-		(property "Value" "USB Type C Connector"
-			(at 100.33 110.49 0)
+		(property "Value" "VCC"
+			(at 209.55 15.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3497,7 +4434,71 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 91.44 90.17 0)
+			(at 209.55 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 209.55 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 209.55 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4edebf73-8541-4bad-bcfb-e4ad8f2bac69")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR040")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:USB_C_Receptacle_USB2.0_16P")
+		(at 95.25 107.95 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d87a5339-2bde-47bd-b2bd-8f67b44aefee")
+		(property "Reference" "J1"
+			(at 104.14 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "USB Type C Connector"
+			(at 107.95 128.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3506,7 +4507,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
-			(at 91.44 90.17 0)
+			(at 99.06 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3515,7 +4516,7 @@
 			)
 		)
 		(property "Description" "USB 2.0-only 16P Type-C Receptacle connector"
-			(at 87.63 90.17 0)
+			(at 95.25 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3585,7 +4586,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 196.85 124.46 0)
+		(at 204.47 142.24 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3594,7 +4595,7 @@
 		(fields_autoplaced yes)
 		(uuid "e1399685-994c-44d8-8173-5fb6616101d6")
 		(property "Reference" "#PWR031"
-			(at 196.85 130.81 0)
+			(at 204.47 148.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3603,7 +4604,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 196.85 129.54 0)
+			(at 204.47 147.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3611,7 +4612,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 196.85 124.46 0)
+			(at 204.47 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3620,7 +4621,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 196.85 124.46 0)
+			(at 204.47 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3629,7 +4630,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 196.85 124.46 0)
+			(at 204.47 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3650,17 +4651,17 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GNDA")
-		(at 189.23 124.46 0)
+		(lib_id "power:VCC")
+		(at 190.5 20.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "fed10362-c97d-4e00-a755-50e4de9b13f9")
-		(property "Reference" "#PWR033"
-			(at 189.23 130.81 0)
+		(uuid "e42e5284-09c5-48a9-b9d5-5d771369bed1")
+		(property "Reference" "#PWR038"
+			(at 190.5 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3668,8 +4669,8 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "GNDA"
-			(at 189.23 129.54 0)
+		(property "Value" "VCC"
+			(at 190.5 15.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3677,7 +4678,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 189.23 124.46 0)
+			(at 190.5 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3686,7 +4687,73 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 189.23 124.46 0)
+			(at 190.5 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 190.5 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b3c6deff-b1d5-4967-a723-b02430ced1f6")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR038")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GNDA")
+		(at 196.85 142.24 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fed10362-c97d-4e00-a755-50e4de9b13f9")
+		(property "Reference" "#PWR033"
+			(at 196.85 148.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GNDA"
+			(at 196.85 147.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 196.85 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 196.85 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3695,7 +4762,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
-			(at 189.23 124.46 0)
+			(at 196.85 142.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -2028,18 +2028,6 @@
 			(embedded_fonts no)
 		)
 	)
-	(text "Reference: Chapter 3.2 of datasheet"
-		(exclude_from_sim no)
-		(at 247.396 50.546 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(color 0 0 0 1)
-			)
-			(justify left)
-		)
-		(uuid "15d99aca-2331-4f4c-a326-4061af767c08")
-	)
 	(text "TX Led"
 		(exclude_from_sim no)
 		(at 192.024 50.546 0)

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -2030,7 +2030,7 @@
 	)
 	(text "TX Led"
 		(exclude_from_sim no)
-		(at 192.024 50.546 0)
+		(at 214.884 50.546 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2041,22 +2041,9 @@
 		)
 		(uuid "3568bc9c-42c1-41a3-a266-c2918c406116")
 	)
-	(text "Power Led"
-		(exclude_from_sim no)
-		(at 229.616 50.546 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(thickness 0.254)
-				(bold yes)
-				(color 0 0 0 1)
-			)
-		)
-		(uuid "439ac335-b5cf-4728-901b-66d196b74c4f")
-	)
 	(text "RX Led"
 		(exclude_from_sim no)
-		(at 211.074 50.546 0)
+		(at 233.934 50.546 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2235,7 +2222,7 @@
 	)
 	(polyline
 		(pts
-			(xy 185.42 12.7) (xy 185.42 52.07)
+			(xy 203.2 12.7) (xy 203.2 52.07)
 		)
 		(stroke
 			(width 0)
@@ -2246,7 +2233,7 @@
 	)
 	(wire
 		(pts
-			(xy 190.5 20.32) (xy 190.5 22.86)
+			(xy 213.36 20.32) (xy 213.36 22.86)
 		)
 		(stroke
 			(width 0)
@@ -2266,7 +2253,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 30.48) (xy 209.55 33.02)
+			(xy 232.41 30.48) (xy 232.41 33.02)
 		)
 		(stroke
 			(width 0)
@@ -2326,7 +2313,7 @@
 	)
 	(wire
 		(pts
-			(xy 190.5 40.64) (xy 190.5 46.99)
+			(xy 213.36 40.64) (xy 213.36 46.99)
 		)
 		(stroke
 			(width 0)
@@ -2336,7 +2323,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 20.32) (xy 209.55 22.86)
+			(xy 232.41 20.32) (xy 232.41 22.86)
 		)
 		(stroke
 			(width 0)
@@ -2388,7 +2375,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 40.64) (xy 209.55 46.99)
+			(xy 232.41 40.64) (xy 232.41 46.99)
 		)
 		(stroke
 			(width 0)
@@ -2429,7 +2416,7 @@
 	)
 	(polyline
 		(pts
-			(xy 242.57 52.07) (xy 185.42 52.07)
+			(xy 242.57 52.07) (xy 203.2 52.07)
 		)
 		(stroke
 			(width 0)
@@ -2540,7 +2527,7 @@
 	)
 	(wire
 		(pts
-			(xy 190.5 30.48) (xy 190.5 33.02)
+			(xy 213.36 30.48) (xy 213.36 33.02)
 		)
 		(stroke
 			(width 0)
@@ -2558,16 +2545,6 @@
 			(color 72 72 72 1)
 		)
 		(uuid "d40401e2-b68c-4156-ad01-caa03f51d41d")
-	)
-	(wire
-		(pts
-			(xy 228.6 30.48) (xy 228.6 33.02)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d6a7c58d-6162-4f76-9055-5aa947c2cc51")
 	)
 	(wire
 		(pts
@@ -2629,16 +2606,6 @@
 			(type default)
 		)
 		(uuid "edfadf42-e0fc-4844-8a26-2f4c84f04824")
-	)
-	(wire
-		(pts
-			(xy 228.6 20.32) (xy 228.6 22.86)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f030e099-eb2c-4416-983b-4bfe66dcef85")
 	)
 	(wire
 		(pts
@@ -2772,7 +2739,7 @@
 		(uuid "c52d0131-fcfd-48cb-b663-4a5d112b4d1e")
 	)
 	(label "TXLED"
-		(at 209.55 46.99 0)
+		(at 232.41 46.99 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2802,7 +2769,7 @@
 		(uuid "dbf596a0-2f3c-4064-a3dd-4acbe3096cd4")
 	)
 	(label "RXLED"
-		(at 190.5 46.99 0)
+		(at 213.36 46.99 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -3219,7 +3186,7 @@
 	)
 	(symbol
 		(lib_id "Device:LED")
-		(at 209.55 26.67 90)
+		(at 232.41 26.67 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3228,7 +3195,7 @@
 		(fields_autoplaced yes)
 		(uuid "2e47384f-0bba-4939-aebb-7bc9de30fd48")
 		(property "Reference" "D3"
-			(at 213.36 26.9874 90)
+			(at 236.22 26.9874 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3237,7 +3204,7 @@
 			)
 		)
 		(property "Value" "LED"
-			(at 213.36 29.5274 90)
+			(at 236.22 29.5274 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3246,7 +3213,7 @@
 			)
 		)
 		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
-			(at 209.55 26.67 0)
+			(at 232.41 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3255,7 +3222,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 209.55 26.67 0)
+			(at 232.41 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3264,7 +3231,7 @@
 			)
 		)
 		(property "Description" "Light emitting diode"
-			(at 209.55 26.67 0)
+			(at 232.41 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3273,7 +3240,7 @@
 			)
 		)
 		(property "Sim.Pins" "1=K 2=A"
-			(at 209.55 26.67 0)
+			(at 232.41 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3561,76 +3528,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 228.6 36.83 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "6ef5e22b-684c-40d3-ad48-28b36b75217f")
-		(property "Reference" "R2"
-			(at 231.14 35.5599 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "150"
-			(at 231.14 38.0999 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 226.822 36.83 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 228.6 36.83 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 228.6 36.83 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "00aec166-b44a-476e-aa32-6b8f69e4252a")
-		)
-		(pin "2"
-			(uuid "ad2c462a-3611-4a44-8ece-a40ff1515599")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "R2")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:VCC")
 		(at 204.47 78.74 0)
 		(unit 1)
@@ -3691,72 +3588,6 @@
 			(project ""
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "#PWR029")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 228.6 40.64 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "7a12e358-f1ac-4e45-9814-23b17c7b000c")
-		(property "Reference" "#PWR037"
-			(at 228.6 46.99 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 228.6 45.72 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 228.6 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 228.6 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 228.6 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "5c953ce9-fec8-4fa7-a538-fe9d6ae6e943")
-		)
-		(instances
-			(project "HW"
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR037")
 					(unit 1)
 				)
 			)
@@ -3829,153 +3660,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:VCC")
-		(at 228.6 20.32 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "7bccaa12-18a5-493a-b57d-f2677039ae8f")
-		(property "Reference" "#PWR036"
-			(at 228.6 24.13 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "VCC"
-			(at 228.6 15.24 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 228.6 20.32 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 228.6 20.32 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 228.6 20.32 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "0fc2d4c3-78cd-404d-a181-806efd6c0493")
-		)
-		(instances
-			(project "HW"
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR036")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:LED")
-		(at 228.6 26.67 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "8455eb92-9069-472e-b8d2-0ed3600c79d7")
-		(property "Reference" "D1"
-			(at 232.41 26.9874 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "LED"
-			(at 232.41 29.5274 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
-			(at 228.6 26.67 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 228.6 26.67 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Light emitting diode"
-			(at 228.6 26.67 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Sim.Pins" "1=K 2=A"
-			(at 228.6 26.67 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "bc22c2de-5f07-4dae-8807-9f1ff152e06f")
-		)
-		(pin "2"
-			(uuid "e94d2bb0-4949-4e7b-b242-7776163ff4c6")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "D1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:R")
-		(at 190.5 36.83 0)
+		(at 213.36 36.83 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3984,7 +3670,7 @@
 		(fields_autoplaced yes)
 		(uuid "89451875-5cdb-4488-8520-6e09b8f34260")
 		(property "Reference" "R3"
-			(at 193.04 35.5599 0)
+			(at 215.9 35.5599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3993,7 +3679,7 @@
 			)
 		)
 		(property "Value" "150"
-			(at 193.04 38.0999 0)
+			(at 215.9 38.0999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4002,7 +3688,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 188.722 36.83 90)
+			(at 211.582 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4011,7 +3697,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 190.5 36.83 0)
+			(at 213.36 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4020,7 +3706,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 190.5 36.83 0)
+			(at 213.36 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4045,7 +3731,7 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 209.55 36.83 0)
+		(at 232.41 36.83 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4054,7 +3740,7 @@
 		(fields_autoplaced yes)
 		(uuid "9483813b-1772-4181-ba5c-d300c40bf602")
 		(property "Reference" "R6"
-			(at 212.09 35.5599 0)
+			(at 234.95 35.5599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4063,7 +3749,7 @@
 			)
 		)
 		(property "Value" "150"
-			(at 212.09 38.0999 0)
+			(at 234.95 38.0999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4072,7 +3758,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 207.772 36.83 90)
+			(at 230.632 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4081,7 +3767,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 209.55 36.83 0)
+			(at 232.41 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4090,7 +3776,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 209.55 36.83 0)
+			(at 232.41 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4115,7 +3801,7 @@
 	)
 	(symbol
 		(lib_id "Device:LED")
-		(at 190.5 26.67 90)
+		(at 213.36 26.67 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4124,7 +3810,7 @@
 		(fields_autoplaced yes)
 		(uuid "94ee5ef2-5a94-4903-bb92-702739feef33")
 		(property "Reference" "D2"
-			(at 194.31 26.9874 90)
+			(at 217.17 26.9874 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4133,7 +3819,7 @@
 			)
 		)
 		(property "Value" "LED"
-			(at 194.31 29.5274 90)
+			(at 217.17 29.5274 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4142,7 +3828,7 @@
 			)
 		)
 		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
-			(at 190.5 26.67 0)
+			(at 213.36 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4151,7 +3837,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 190.5 26.67 0)
+			(at 213.36 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4160,7 +3846,7 @@
 			)
 		)
 		(property "Description" "Light emitting diode"
-			(at 190.5 26.67 0)
+			(at 213.36 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4169,7 +3855,7 @@
 			)
 		)
 		(property "Sim.Pins" "1=K 2=A"
-			(at 190.5 26.67 0)
+			(at 213.36 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4396,7 +4082,7 @@
 	)
 	(symbol
 		(lib_id "power:VCC")
-		(at 209.55 20.32 0)
+		(at 232.41 20.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4405,7 +4091,7 @@
 		(fields_autoplaced yes)
 		(uuid "c9005292-8e8f-45de-90b9-1b291032a771")
 		(property "Reference" "#PWR040"
-			(at 209.55 24.13 0)
+			(at 232.41 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4414,7 +4100,7 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 209.55 15.24 0)
+			(at 232.41 15.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4422,7 +4108,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 209.55 20.32 0)
+			(at 232.41 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4431,7 +4117,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 209.55 20.32 0)
+			(at 232.41 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4440,7 +4126,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 209.55 20.32 0)
+			(at 232.41 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4640,7 +4326,7 @@
 	)
 	(symbol
 		(lib_id "power:VCC")
-		(at 190.5 20.32 0)
+		(at 213.36 20.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4649,7 +4335,7 @@
 		(fields_autoplaced yes)
 		(uuid "e42e5284-09c5-48a9-b9d5-5d771369bed1")
 		(property "Reference" "#PWR038"
-			(at 190.5 24.13 0)
+			(at 213.36 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4658,7 +4344,7 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 190.5 15.24 0)
+			(at 213.36 15.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4666,7 +4352,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 190.5 20.32 0)
+			(at 213.36 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4675,7 +4361,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 190.5 20.32 0)
+			(at 213.36 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4684,7 +4370,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 190.5 20.32 0)
+			(at 213.36 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -1845,6 +1845,18 @@
 			(embedded_fonts no)
 		)
 	)
+	(text "Reference: Chapter 3.2 of datasheet"
+		(exclude_from_sim no)
+		(at 247.142 41.402 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(color 0 0 0 1)
+			)
+			(justify left)
+		)
+		(uuid "15d99aca-2331-4f4c-a326-4061af767c08")
+	)
 	(text "Power Out\n"
 		(exclude_from_sim no)
 		(at 18.542 17.018 0)
@@ -1941,16 +1953,6 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 82.55) (xy 114.3 82.55)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0d7de10e-eb62-41f5-b34d-13bbe11768e8")
-	)
-	(wire
-		(pts
 			(xy 102.87 88.9) (xy 110.49 88.9)
 		)
 		(stroke
@@ -1971,16 +1973,6 @@
 	)
 	(wire
 		(pts
-			(xy 125.73 82.55) (xy 125.73 85.09)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "1d3460e6-11b9-4678-a32f-479c77fa97c2")
-	)
-	(wire
-		(pts
 			(xy 196.85 116.84) (xy 199.39 116.84)
 		)
 		(stroke
@@ -1988,16 +1980,6 @@
 			(type default)
 		)
 		(uuid "1fcdc215-11b5-4c84-bb04-d1165c5c8eee")
-	)
-	(wire
-		(pts
-			(xy 132.08 80.01) (xy 132.08 85.09)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "21a76361-1d4c-4bb3-8d0f-a1ba0dfbc91d")
 	)
 	(wire
 		(pts
@@ -2041,6 +2023,16 @@
 	)
 	(wire
 		(pts
+			(xy 102.87 82.55) (xy 110.49 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c0fdda9-740f-4b8f-8955-0ff7b94a87e1")
+	)
+	(wire
+		(pts
 			(xy 214.63 76.2) (xy 220.98 76.2)
 		)
 		(stroke
@@ -2081,6 +2073,16 @@
 	)
 	(wire
 		(pts
+			(xy 274.32 29.21) (xy 274.32 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7184cca3-6781-45b0-afae-9cc2e11d6b2f")
+	)
+	(wire
+		(pts
 			(xy 149.86 81.28) (xy 149.86 87.63)
 		)
 		(stroke
@@ -2112,16 +2114,6 @@
 	)
 	(wire
 		(pts
-			(xy 121.92 82.55) (xy 125.73 82.55)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "82879b8e-e1c2-4fa1-b772-6c32a9fb1515")
-	)
-	(wire
-		(pts
 			(xy 110.49 74.93) (xy 102.87 74.93)
 		)
 		(stroke
@@ -2129,6 +2121,17 @@
 			(type default)
 		)
 		(uuid "85d6b289-c01a-43a0-b8fb-a693135644aa")
+	)
+	(polyline
+		(pts
+			(xy 284.48 43.18) (xy 245.11 43.18)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "8726fb0d-8be2-4925-8431-1107e168f9dd")
 	)
 	(wire
 		(pts
@@ -2152,6 +2155,16 @@
 	)
 	(wire
 		(pts
+			(xy 256.54 29.21) (xy 256.54 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "923d994b-c738-480b-ab05-d0f08207a8a9")
+	)
+	(wire
+		(pts
 			(xy 167.64 109.22) (xy 167.64 124.46)
 		)
 		(stroke
@@ -2159,16 +2172,6 @@
 			(type default)
 		)
 		(uuid "9b093f9b-346f-4ce0-8dd4-e5ee3e43cce5")
-	)
-	(wire
-		(pts
-			(xy 102.87 80.01) (xy 120.65 80.01)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a036df97-bcd1-4561-b913-a7b70e890dd5")
 	)
 	(wire
 		(pts
@@ -2199,6 +2202,16 @@
 			(type default)
 		)
 		(uuid "af8cd4bb-1848-4d31-a7a4-86b7c4d4882d")
+	)
+	(wire
+		(pts
+			(xy 256.54 16.51) (xy 256.54 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bd99dfa6-edd4-4063-9685-911ddd3b75e4")
 	)
 	(wire
 		(pts
@@ -2243,6 +2256,26 @@
 	)
 	(wire
 		(pts
+			(xy 102.87 80.01) (xy 110.49 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df177d23-d424-4921-8593-822b1d505dd0")
+	)
+	(wire
+		(pts
+			(xy 274.32 16.51) (xy 274.32 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e44c1e04-3961-447b-afa1-8fe962ef4ec1")
+	)
+	(wire
+		(pts
 			(xy 102.87 88.9) (xy 102.87 90.17)
 		)
 		(stroke
@@ -2261,6 +2294,17 @@
 		)
 		(uuid "f953afcf-be9b-4ae7-a747-e49c8fb9a403")
 	)
+	(polyline
+		(pts
+			(xy 245.11 43.18) (xy 245.11 12.7)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "fa2882d7-bf3b-4dac-aab4-7cb370e68e15")
+	)
 	(wire
 		(pts
 			(xy 87.63 113.03) (xy 87.63 116.84)
@@ -2271,15 +2315,15 @@
 		)
 		(uuid "fba18a9c-d0de-4de3-817a-196796f86279")
 	)
-	(wire
-		(pts
-			(xy 128.27 80.01) (xy 132.08 80.01)
+	(label "CC2"
+		(at 274.32 16.51 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
 		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ff7a5c06-4a9c-4168-9c2b-8e3f5dfb770e")
+		(uuid "258bf8e1-2933-433e-a0cf-64b0c3ccfce9")
 	)
 	(label "USBD+"
 		(at 110.49 88.9 180)
@@ -2291,6 +2335,16 @@
 		)
 		(uuid "26a746a3-750b-4cc6-9767-bd8c7172c191")
 	)
+	(label "CC1"
+		(at 110.49 80.01 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "310fe3b4-3e03-42a6-82f9-ca9749fa7d99")
+	)
 	(label "USBD-"
 		(at 167.64 83.82 180)
 		(effects
@@ -2301,6 +2355,16 @@
 		)
 		(uuid "4083e950-aad2-4521-a4ac-b8521f65c8d6")
 	)
+	(label "CC1"
+		(at 256.54 16.51 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a641cc17-7d4f-4b0b-b4b8-10aaea87dc55")
+	)
 	(label "USBD-"
 		(at 110.49 93.98 180)
 		(effects
@@ -2310,6 +2374,16 @@
 			(justify right bottom)
 		)
 		(uuid "b7a1861c-e729-499f-a464-9da1ae688101")
+	)
+	(label "CC2"
+		(at 110.49 82.55 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c52d0131-fcfd-48cb-b663-4a5d112b4d1e")
 	)
 	(label "USBD+"
 		(at 167.64 81.28 180)
@@ -2333,7 +2407,7 @@
 		(uuid "3ffd6bca-4c91-423b-8fa7-7f4ca7ee9bbe")
 	)
 	(hierarchical_label "UART_TXD"
-		(shape bidirectional)
+		(shape output)
 		(at 220.98 73.66 0)
 		(effects
 			(font
@@ -2355,7 +2429,7 @@
 		(uuid "c6d0db75-de7f-4394-a203-3354e9d8054a")
 	)
 	(hierarchical_label "UART_RXD"
-		(shape bidirectional)
+		(shape input)
 		(at 220.98 76.2 0)
 		(effects
 			(font
@@ -2366,24 +2440,26 @@
 		(uuid "d9e3a63f-de3c-4379-a102-4b09abf7cf24")
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 124.46 80.01 90)
+		(lib_id "power:GND")
+		(at 274.32 31.75 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0a7f8205-cb9b-4a21-b8ee-c32363a66fac")
-		(property "Reference" "R2"
-			(at 124.46 73.66 90)
+		(fields_autoplaced yes)
+		(uuid "0d167cf5-c721-4d62-b48e-35cf1dec132e")
+		(property "Reference" "#PWR035"
+			(at 274.32 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(hide yes)
 			)
 		)
-		(property "Value" "5.1k"
-			(at 124.46 76.2 90)
+		(property "Value" "GND"
+			(at 274.32 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2391,7 +2467,71 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 124.46 81.788 90)
+			(at 274.32 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 274.32 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 274.32 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "98cb59a4-35de-4712-a3cd-6f9cb2721db3")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR035")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 274.32 25.4 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d308bd9-cecb-48ef-b4f2-fa875fc0a3c5")
+		(property "Reference" "R5"
+			(at 267.97 25.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 270.51 25.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 276.098 25.4 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2400,7 +2540,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 124.46 80.01 0)
+			(at 274.32 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2409,7 +2549,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 124.46 80.01 0)
+			(at 274.32 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2418,15 +2558,15 @@
 			)
 		)
 		(pin "2"
-			(uuid "87060908-e108-4b57-b73b-9d0a6d5c50a3")
+			(uuid "71692d40-9838-481f-ac0c-95d46b211079")
 		)
 		(pin "1"
-			(uuid "791db98f-63f8-41d0-ad0d-a4a071c56b75")
+			(uuid "7da925d6-b4d0-4915-9db3-4f471ba7682f")
 		)
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "R2")
+					(reference "R5")
 					(unit 1)
 				)
 			)
@@ -2707,17 +2847,84 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R")
+		(at 256.54 25.4 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "342aeb10-0bfd-45a0-a129-74967514fbf4")
+		(property "Reference" "R4"
+			(at 250.19 25.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 252.73 25.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 258.318 25.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 256.54 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "80e7702e-33bf-4536-9f56-bf7f955ab0bf")
+		)
+		(pin "1"
+			(uuid "928b0a81-907f-4775-9d1d-bf96bdc0506e")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "R4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
-		(at 125.73 85.09 0)
+		(at 256.54 31.75 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "3f6bc562-9d34-4fa8-865b-42e3b6aab824")
-		(property "Reference" "#PWR024"
-			(at 125.73 91.44 0)
+		(uuid "3fc5b8d7-c07b-4c23-a54c-53bc69f574f4")
+		(property "Reference" "#PWR034"
+			(at 256.54 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2726,7 +2933,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 125.73 90.17 0)
+			(at 256.54 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2734,7 +2941,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 125.73 85.09 0)
+			(at 256.54 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2743,7 +2950,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 125.73 85.09 0)
+			(at 256.54 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2752,7 +2959,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 125.73 85.09 0)
+			(at 256.54 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2761,12 +2968,12 @@
 			)
 		)
 		(pin "1"
-			(uuid "37bccff7-7dfc-42a3-adb6-2a526244f409")
+			(uuid "1a9978a9-4f24-428f-890e-6f4413e8c608")
 		)
 		(instances
-			(project "HW"
+			(project ""
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR024")
+					(reference "#PWR034")
 					(unit 1)
 				)
 			)
@@ -2832,71 +3039,6 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "#PWR017")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 132.08 85.09 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "4bea2cdc-6222-49d7-ab9d-ee490ab17234")
-		(property "Reference" "#PWR023"
-			(at 132.08 91.44 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 132.08 90.17 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 132.08 85.09 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 132.08 85.09 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 132.08 85.09 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "34d5b0d5-98f1-4755-8241-a44351b4a7f1")
-		)
-		(instances
-			(project "HW"
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR023")
 					(unit 1)
 				)
 			)
@@ -3343,74 +3485,6 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "J1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 118.11 82.55 90)
-		(mirror x)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "d9514cba-8fa6-455f-926e-02aa139d6616")
-		(property "Reference" "R3"
-			(at 118.11 88.9 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "5.1k"
-			(at 118.11 86.36 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 118.11 80.772 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 118.11 82.55 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 118.11 82.55 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "106dcb14-7bf2-48c8-9061-ee2e0791d8d8")
-		)
-		(pin "2"
-			(uuid "8028f3f6-d79c-45a2-9402-316fffd4047c")
-		)
-		(instances
-			(project "HW"
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "R3")
 					(unit 1)
 				)
 			)

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -3524,7 +3524,7 @@
 				(justify right)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0805_2012Metric_Pad1.18x1.45mm_HandSolder"
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
 			(at 267.97 43.18 0)
 			(effects
 				(font

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -1667,6 +1667,19 @@
 		)
 		(uuid "bc5f528c-9020-4fb2-941b-d5cac158d96c")
 	)
+	(text "Reset Out\n"
+		(exclude_from_sim no)
+		(at 50.292 50.546 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "c23d8ccb-7cda-48f2-ac2c-edb78d354c58")
+	)
 	(text "{"
 		(exclude_from_sim no)
 		(at 212.09 36.83 0)
@@ -1757,6 +1770,17 @@
 		)
 		(uuid "1732c532-21fc-4d6d-a610-26854d1bb7c9")
 	)
+	(polyline
+		(pts
+			(xy 63.5 68.58) (xy 63.5 46.99)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "17ba8e62-289a-4263-bedb-8bf888a8b9a1")
+	)
 	(wire
 		(pts
 			(xy 161.29 81.28) (xy 157.48 81.28)
@@ -1838,6 +1862,17 @@
 		)
 		(uuid "3748acbe-57f8-4fb2-85c3-edc1fa2853f7")
 	)
+	(polyline
+		(pts
+			(xy 36.83 68.58) (xy 63.5 68.58)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "4a55d3c6-e319-4cdc-a89f-d027febf7b88")
+	)
 	(wire
 		(pts
 			(xy 223.52 40.64) (xy 223.52 45.72)
@@ -1888,6 +1923,16 @@
 			(type default)
 		)
 		(uuid "648eeab1-6f23-4425-95fe-4f35c94f7ba2")
+	)
+	(wire
+		(pts
+			(xy 48.26 64.77) (xy 57.15 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "65807427-7c44-44f6-a05c-129c542bf2db")
 	)
 	(wire
 		(pts
@@ -1979,6 +2024,16 @@
 			(type default)
 		)
 		(uuid "9a2789f2-13f1-4cdc-8f56-40f77f8b96ea")
+	)
+	(wire
+		(pts
+			(xy 57.15 55.88) (xy 57.15 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9ce2d3f5-a992-4c15-879b-aa2334827258")
 	)
 	(wire
 		(pts
@@ -2165,6 +2220,16 @@
 		(uuid "2620004f-9060-47d5-8115-e0331145ad42")
 	)
 	(label "NRST"
+		(at 57.15 55.88 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "27af42af-34c5-4eb4-9053-c228a4cc015f")
+	)
+	(label "NRST"
 		(at 134.62 90.17 0)
 		(effects
 			(font
@@ -2194,6 +2259,17 @@
 			(justify left)
 		)
 		(uuid "241ddd63-9a75-49c3-bbf8-b7de8c962f65")
+	)
+	(hierarchical_label "RESET"
+		(shape output)
+		(at 48.26 64.77 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "60478b07-0c38-45a4-a957-ff8067aa5a69")
 	)
 	(hierarchical_label "VCC"
 		(shape input)

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -1684,6 +1684,16 @@
 		(color 0 0 0 0)
 		(uuid "7606d7f0-753e-429f-b85b-b084aff8e499")
 	)
+	(wire
+		(pts
+			(xy 167.64 110.49) (xy 171.45 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "01adc481-8bb1-42f2-8971-c9e9d41fca8a")
+	)
 	(polyline
 		(pts
 			(xy 48.26 12.7) (xy 48.26 46.99)
@@ -2021,6 +2031,16 @@
 		)
 		(uuid "bd74061c-deeb-4a6e-8dab-68bf03124db3")
 	)
+	(wire
+		(pts
+			(xy 167.64 113.03) (xy 171.45 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3dde6da-8a2c-46b8-b6a4-c34602468837")
+	)
 	(polyline
 		(pts
 			(xy 12.7 68.58) (xy 36.83 68.58)
@@ -2164,6 +2184,17 @@
 		)
 		(uuid "bb1c31a7-5734-47b2-9091-2d3be86dc289")
 	)
+	(hierarchical_label "USART1_TX"
+		(shape bidirectional)
+		(at 171.45 110.49 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "241ddd63-9a75-49c3-bbf8-b7de8c962f65")
+	)
 	(hierarchical_label "VCC"
 		(shape input)
 		(at 22.86 60.96 180)
@@ -2174,6 +2205,17 @@
 			(justify right)
 		)
 		(uuid "98ada678-ff73-40de-af17-66eb4392ff01")
+	)
+	(hierarchical_label "USART1_RX"
+		(shape bidirectional)
+		(at 171.45 113.03 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d9074387-bf68-415e-bbb0-8bd75ca6cdc3")
 	)
 	(hierarchical_label "VCCCA"
 		(shape input)

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -2272,7 +2272,7 @@
 		(uuid "60478b07-0c38-45a4-a957-ff8067aa5a69")
 	)
 	(hierarchical_label "VCC"
-		(shape input)
+		(shape passive)
 		(at 22.86 60.96 180)
 		(effects
 			(font
@@ -2294,7 +2294,7 @@
 		(uuid "d9074387-bf68-415e-bbb0-8bd75ca6cdc3")
 	)
 	(hierarchical_label "VCCCA"
-		(shape input)
+		(shape passive)
 		(at 22.86 64.77 180)
 		(effects
 			(font

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -2185,7 +2185,7 @@
 		(uuid "bb1c31a7-5734-47b2-9091-2d3be86dc289")
 	)
 	(hierarchical_label "USART1_TX"
-		(shape bidirectional)
+		(shape output)
 		(at 171.45 110.49 0)
 		(effects
 			(font
@@ -2207,7 +2207,7 @@
 		(uuid "98ada678-ff73-40de-af17-66eb4392ff01")
 	)
 	(hierarchical_label "USART1_RX"
-		(shape bidirectional)
+		(shape input)
 		(at 171.45 113.03 0)
 		(effects
 			(font

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -3799,7 +3799,7 @@
 				)
 			)
 		)
-		(property "Footprint" "Resistor_SMD:R_0201_0603Metric_Pad0.64x0.40mm_HandSolder"
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
 			(at 227.33 38.1 0)
 			(effects
 				(font

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -5,703 +5,6 @@
 	(uuid "7619e000-1585-44bf-ab4e-f02c1cf47ac3")
 	(paper "A4")
 	(lib_symbols
-		(symbol "Connector:USB_C_Receptacle_USB2.0_16P"
-			(pin_names
-				(offset 1.016)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "J"
-				(at 0 22.225 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "USB_C_Receptacle_USB2.0_16P"
-				(at 0 19.685 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" ""
-				(at 3.81 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
-				(at 3.81 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "USB 2.0-only 16P Type-C Receptacle connector"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "usb universal serial bus type-C USB2.0"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "USB*C*Receptacle*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "USB_C_Receptacle_USB2.0_16P_0_0"
-				(rectangle
-					(start -0.254 -17.78)
-					(end 0.254 -16.764)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 15.494)
-					(end 9.144 14.986)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 10.414)
-					(end 9.144 9.906)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 7.874)
-					(end 9.144 7.366)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 2.794)
-					(end 9.144 2.286)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 0.254)
-					(end 9.144 -0.254)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 -2.286)
-					(end 9.144 -2.794)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 -4.826)
-					(end 9.144 -5.334)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 -12.446)
-					(end 9.144 -12.954)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 10.16 -14.986)
-					(end 9.144 -15.494)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-			)
-			(symbol "USB_C_Receptacle_USB2.0_16P_0_1"
-				(rectangle
-					(start -10.16 17.78)
-					(end 10.16 -17.78)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(polyline
-					(pts
-						(xy -8.89 -3.81) (xy -8.89 3.81)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start -7.62 -3.81)
-					(end -6.35 3.81)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-				(arc
-					(start -7.62 3.81)
-					(mid -6.985 4.4423)
-					(end -6.35 3.81)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start -7.62 3.81)
-					(mid -6.985 4.4423)
-					(end -6.35 3.81)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-				(arc
-					(start -8.89 3.81)
-					(mid -6.985 5.7067)
-					(end -5.08 3.81)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start -5.08 -3.81)
-					(mid -6.985 -5.7067)
-					(end -8.89 -3.81)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start -6.35 -3.81)
-					(mid -6.985 -4.4423)
-					(end -7.62 -3.81)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start -6.35 -3.81)
-					(mid -6.985 -4.4423)
-					(end -7.62 -3.81)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-				(polyline
-					(pts
-						(xy -5.08 3.81) (xy -5.08 -3.81)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(circle
-					(center -2.54 1.143)
-					(radius 0.635)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.27 4.318) (xy 0 6.858) (xy 1.27 4.318) (xy -1.27 4.318)
-					)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-				(polyline
-					(pts
-						(xy 0 -2.032) (xy 2.54 0.508) (xy 2.54 1.778)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 0 -3.302) (xy -2.54 -0.762) (xy -2.54 0.508)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 0 -5.842) (xy 0 4.318)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(circle
-					(center 0 -5.842)
-					(radius 1.27)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-				(rectangle
-					(start 1.905 1.778)
-					(end 3.175 3.048)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-			)
-			(symbol "USB_C_Receptacle_USB2.0_16P_1_1"
-				(pin passive line
-					(at -7.62 -22.86 90)
-					(length 5.08)
-					(name "SHIELD"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "S1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -22.86 90)
-					(length 5.08)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -22.86 90)
-					(length 5.08)
-					(hide yes)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -22.86 90)
-					(length 5.08)
-					(hide yes)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -22.86 90)
-					(length 5.08)
-					(hide yes)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 15.24 15.24 180)
-					(length 5.08)
-					(name "VBUS"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 15.24 15.24 180)
-					(length 5.08)
-					(hide yes)
-					(name "VBUS"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 15.24 15.24 180)
-					(length 5.08)
-					(hide yes)
-					(name "VBUS"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 15.24 15.24 180)
-					(length 5.08)
-					(hide yes)
-					(name "VBUS"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 10.16 180)
-					(length 5.08)
-					(name "CC1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 7.62 180)
-					(length 5.08)
-					(name "CC2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 2.54 180)
-					(length 5.08)
-					(name "D-"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 0 180)
-					(length 5.08)
-					(name "D-"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 -2.54 180)
-					(length 5.08)
-					(name "D+"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 -5.08 180)
-					(length 5.08)
-					(name "D+"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 -12.7 180)
-					(length 5.08)
-					(name "SBU1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "A8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 15.24 -15.24 180)
-					(length 5.08)
-					(name "SBU2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "B8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
 		(symbol "Device:C_Small"
 			(pin_numbers
 				(hide yes)
@@ -974,130 +277,6 @@
 				)
 				(pin passive line
 					(at 0 -2.54 90)
-					(length 1.27)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
-		(symbol "Device:R"
-			(pin_numbers
-				(hide yes)
-			)
-			(pin_names
-				(offset 0)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "R"
-				(at 2.032 0 90)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "R"
-				(at 0 0 90)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" ""
-				(at -1.778 0 90)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "~"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "Resistor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "R res resistor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "R_*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "R_0_1"
-				(rectangle
-					(start -1.016 -2.54)
-					(end 1.016 2.54)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-			)
-			(symbol "R_1_1"
-				(pin passive line
-					(at 0 3.81 270)
-					(length 1.27)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -3.81 90)
 					(length 1.27)
 					(name "~"
 						(effects
@@ -1481,7 +660,7 @@
 			(embedded_fonts no)
 		)
 	)
-	(text "Power Out\n"
+	(text "Power In\n"
 		(exclude_from_sim no)
 		(at 21.082 15.748 0)
 		(effects
@@ -1494,46 +673,26 @@
 		(uuid "1e021d74-c193-45bd-9b89-7c422f254d45")
 	)
 	(junction
-		(at 218.44 99.06)
+		(at 168.91 101.6)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "374f4c9f-e852-4ee2-9efe-f4140cd71971")
 	)
 	(junction
-		(at 97.79 100.33)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "63e3be57-075c-467a-86b2-e2b779ab37b4")
-	)
-	(junction
-		(at 226.06 99.06)
+		(at 176.53 101.6)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "bc3011ec-c9a9-4368-9d7a-2a95989f7526")
 	)
 	(junction
-		(at 179.07 99.06)
+		(at 129.54 101.6)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "be55d9e0-e73a-4613-8773-ad5bd5934cb8")
 	)
-	(junction
-		(at 97.79 105.41)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "f877545b-e035-46ef-9450-110450ce7b83")
-	)
-	(no_connect
-		(at 97.79 114.3)
-		(uuid "651f93cf-5fec-41e4-8c9c-c4d6b1efac64")
-	)
-	(no_connect
-		(at 97.79 116.84)
-		(uuid "e66dadbb-cebd-460a-b609-03383928787a")
-	)
 	(wire
 		(pts
-			(xy 218.44 99.06) (xy 218.44 100.33)
+			(xy 168.91 101.6) (xy 168.91 102.87)
 		)
 		(stroke
 			(width 0)
@@ -1543,7 +702,7 @@
 	)
 	(wire
 		(pts
-			(xy 35.56 27.94) (xy 35.56 34.29)
+			(xy 17.78 27.94) (xy 17.78 34.29)
 		)
 		(stroke
 			(width 0)
@@ -1553,7 +712,7 @@
 	)
 	(wire
 		(pts
-			(xy 179.07 106.68) (xy 179.07 110.49)
+			(xy 129.54 109.22) (xy 129.54 113.03)
 		)
 		(stroke
 			(width 0)
@@ -1563,27 +722,7 @@
 	)
 	(wire
 		(pts
-			(xy 82.55 124.46) (xy 82.55 128.27)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "21b6cc47-820f-497e-aef7-e55642b2200a")
-	)
-	(wire
-		(pts
-			(xy 123.19 91.44) (xy 127 91.44)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "25f70f45-0a9e-42d4-8f37-7a1124ef9f8f")
-	)
-	(wire
-		(pts
-			(xy 226.06 88.9) (xy 226.06 83.82)
+			(xy 176.53 91.44) (xy 176.53 86.36)
 		)
 		(stroke
 			(width 0)
@@ -1593,17 +732,7 @@
 	)
 	(wire
 		(pts
-			(xy 97.79 100.33) (xy 97.79 101.6)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "301bce74-306f-4ae9-b372-6bcc652eeff2")
-	)
-	(wire
-		(pts
-			(xy 226.06 93.98) (xy 226.06 99.06)
+			(xy 176.53 96.52) (xy 176.53 101.6)
 		)
 		(stroke
 			(width 0)
@@ -1613,27 +742,7 @@
 	)
 	(wire
 		(pts
-			(xy 97.79 105.41) (xy 97.79 106.68)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "338b1bce-0b6f-4142-92ff-9f72356855f8")
-	)
-	(wire
-		(pts
-			(xy 116.84 93.98) (xy 120.65 93.98)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3f7e0693-993c-41c4-96a4-f43a117943e6")
-	)
-	(wire
-		(pts
-			(xy 25.4 34.29) (xy 35.56 34.29)
+			(xy 27.94 34.29) (xy 17.78 34.29)
 		)
 		(stroke
 			(width 0)
@@ -1643,17 +752,7 @@
 	)
 	(wire
 		(pts
-			(xy 120.65 93.98) (xy 120.65 96.52)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "493e57a1-50db-49ef-95d8-49cbca54ff57")
-	)
-	(wire
-		(pts
-			(xy 199.39 106.68) (xy 199.39 110.49)
+			(xy 149.86 109.22) (xy 149.86 113.03)
 		)
 		(stroke
 			(width 0)
@@ -1663,27 +762,7 @@
 	)
 	(wire
 		(pts
-			(xy 97.79 104.14) (xy 97.79 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5c2d54e4-03a5-48c8-a468-8110ede7ee63")
-	)
-	(wire
-		(pts
-			(xy 97.79 99.06) (xy 97.79 100.33)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5d4387a9-5ff1-4dee-bfa9-ef5a64460d0e")
-	)
-	(wire
-		(pts
-			(xy 226.06 83.82) (xy 229.87 83.82)
+			(xy 176.53 86.36) (xy 180.34 86.36)
 		)
 		(stroke
 			(width 0)
@@ -1693,7 +772,7 @@
 	)
 	(wire
 		(pts
-			(xy 226.06 99.06) (xy 229.87 99.06)
+			(xy 176.53 101.6) (xy 180.34 101.6)
 		)
 		(stroke
 			(width 0)
@@ -1703,27 +782,7 @@
 	)
 	(wire
 		(pts
-			(xy 97.79 105.41) (xy 105.41 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "635befa3-ea10-4778-9770-065170cb7a71")
-	)
-	(wire
-		(pts
-			(xy 74.93 124.46) (xy 74.93 128.27)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "966bafd1-43d3-4dac-afea-a3ca4f9157a6")
-	)
-	(wire
-		(pts
-			(xy 218.44 105.41) (xy 218.44 110.49)
+			(xy 168.91 107.95) (xy 168.91 113.03)
 		)
 		(stroke
 			(width 0)
@@ -1733,33 +792,13 @@
 	)
 	(wire
 		(pts
-			(xy 207.01 99.06) (xy 218.44 99.06)
+			(xy 157.48 101.6) (xy 168.91 101.6)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "9c95b28b-9026-437c-98a9-310ec4cfbb61")
-	)
-	(wire
-		(pts
-			(xy 97.79 93.98) (xy 109.22 93.98)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a9220753-33c8-46c4-b1c9-c88731ddeb91")
-	)
-	(wire
-		(pts
-			(xy 105.41 86.36) (xy 97.79 86.36)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ab6edf25-542d-498d-baa8-f5654dca5f9d")
 	)
 	(polyline
 		(pts
@@ -1771,16 +810,6 @@
 			(color 72 72 72 1)
 		)
 		(uuid "acd98e81-6fcc-4a0a-beaf-3fb110dfa060")
-	)
-	(wire
-		(pts
-			(xy 97.79 91.44) (xy 115.57 91.44)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b9cd2588-cf25-4ec8-8c21-ee48e9429521")
 	)
 	(polyline
 		(pts
@@ -1795,7 +824,7 @@
 	)
 	(wire
 		(pts
-			(xy 179.07 99.06) (xy 179.07 101.6)
+			(xy 129.54 101.6) (xy 129.54 104.14)
 		)
 		(stroke
 			(width 0)
@@ -1805,7 +834,7 @@
 	)
 	(wire
 		(pts
-			(xy 191.77 99.06) (xy 179.07 99.06)
+			(xy 142.24 101.6) (xy 129.54 101.6)
 		)
 		(stroke
 			(width 0)
@@ -1815,17 +844,7 @@
 	)
 	(wire
 		(pts
-			(xy 127 91.44) (xy 127 96.52)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "da8da93b-e69b-42bf-8350-db598431aa1c")
-	)
-	(wire
-		(pts
-			(xy 218.44 99.06) (xy 226.06 99.06)
+			(xy 168.91 101.6) (xy 176.53 101.6)
 		)
 		(stroke
 			(width 0)
@@ -1835,7 +854,7 @@
 	)
 	(wire
 		(pts
-			(xy 166.37 99.06) (xy 179.07 99.06)
+			(xy 116.84 101.6) (xy 129.54 101.6)
 		)
 		(stroke
 			(width 0)
@@ -1843,19 +862,9 @@
 		)
 		(uuid "ea0a56ea-ac29-4126-8aee-09ab9c8fbf88")
 	)
-	(wire
-		(pts
-			(xy 97.79 100.33) (xy 105.41 100.33)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f80ec31d-db0d-4abe-91a2-9b76b2cef664")
-	)
 	(hierarchical_label "3V3_VCCA"
 		(shape output)
-		(at 229.87 83.82 0)
+		(at 180.34 86.36 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1866,7 +875,7 @@
 	)
 	(hierarchical_label "3V3_VCC"
 		(shape output)
-		(at 229.87 99.06 0)
+		(at 180.34 101.6 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1875,31 +884,9 @@
 		)
 		(uuid "dc7e80f9-fd1c-4c88-a6d8-bc8504069dce")
 	)
-	(hierarchical_label "D-"
-		(shape bidirectional)
-		(at 105.41 105.41 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "e1326f4c-67f4-4864-b8d8-3e9cd208201b")
-	)
-	(hierarchical_label "D+"
-		(shape bidirectional)
-		(at 105.41 100.33 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "e3a04937-5736-4bfb-8fd9-2e980c3c8e9e")
-	)
 	(hierarchical_label "USB_VCC"
 		(shape output)
-		(at 35.56 27.94 90)
+		(at 17.78 27.94 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1909,75 +896,8 @@
 		(uuid "eea4b2f5-7699-4f6a-a763-54302c808bc0")
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 119.38 91.44 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "0a7f8205-cb9b-4a21-b8ee-c32363a66fac")
-		(property "Reference" "R2"
-			(at 119.38 85.09 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "5.1k"
-			(at 119.38 87.63 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 119.38 93.218 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 119.38 91.44 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 119.38 91.44 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "87060908-e108-4b57-b73b-9d0a6d5c50a3")
-		)
-		(pin "1"
-			(uuid "791db98f-63f8-41d0-ad0d-a4a071c56b75")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "R2")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Regulator_Linear:LM1117MP-3.3")
-		(at 199.39 99.06 0)
+		(at 149.86 101.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1985,7 +905,7 @@
 		(dnp no)
 		(uuid "0bca257c-9d96-4df8-af63-d39dd161329f")
 		(property "Reference" "U3"
-			(at 203.2 95.25 0)
+			(at 153.67 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1993,7 +913,7 @@
 			)
 		)
 		(property "Value" "LM1117MP-3.3"
-			(at 207.01 105.41 0)
+			(at 157.48 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2001,7 +921,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
-			(at 199.39 99.06 0)
+			(at 149.86 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2010,7 +930,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/lm1117.pdf"
-			(at 199.39 99.06 0)
+			(at 149.86 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2019,7 +939,7 @@
 			)
 		)
 		(property "Description" "800mA Low-Dropout Linear Regulator, 3.3V fixed output, SOT-223"
-			(at 199.39 99.06 0)
+			(at 149.86 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2046,74 +966,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 120.65 96.52 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "3f6bc562-9d34-4fa8-865b-42e3b6aab824")
-		(property "Reference" "#PWR024"
-			(at 120.65 102.87 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 120.65 101.6 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 120.65 96.52 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 120.65 96.52 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 120.65 96.52 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "37bccff7-7dfc-42a3-adb6-2a526244f409")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR024")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:C_Small")
-		(at 218.44 102.87 0)
+		(at 168.91 105.41 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2121,7 +975,7 @@
 		(dnp no)
 		(uuid "462b8421-9a2c-472e-a4a4-62251f915fcb")
 		(property "Reference" "C2"
-			(at 219.71 100.33 0)
+			(at 170.18 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2130,7 +984,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 219.71 105.41 0)
+			(at 170.18 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2139,7 +993,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 218.44 102.87 0)
+			(at 168.91 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2148,7 +1002,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 218.44 102.87 0)
+			(at 168.91 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2157,7 +1011,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor, small symbol"
-			(at 218.44 102.87 0)
+			(at 168.91 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2181,139 +1035,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 82.55 128.27 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "4bbfee0f-4141-4876-a671-ada67be7a61f")
-		(property "Reference" "#PWR017"
-			(at 82.55 134.62 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 82.55 132.08 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 82.55 128.27 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 82.55 128.27 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 82.55 128.27 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "f27a9e07-b846-48e0-a743-ba5cd2f761a4")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR017")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 127 96.52 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "4bea2cdc-6222-49d7-ab9d-ee490ab17234")
-		(property "Reference" "#PWR023"
-			(at 127 102.87 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 127 101.6 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 127 96.52 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 127 96.52 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 127 96.52 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "34d5b0d5-98f1-4755-8241-a44351b4a7f1")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR023")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:VCC")
-		(at 25.4 34.29 90)
-		(mirror x)
+		(at 27.94 34.29 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2321,7 +1044,7 @@
 		(dnp no)
 		(uuid "58fba050-cf77-4c14-b8d8-6d33464e2fd4")
 		(property "Reference" "#PWR028"
-			(at 29.21 34.29 0)
+			(at 24.13 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2330,7 +1053,7 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 21.59 34.2899 90)
+			(at 31.75 34.2899 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2339,7 +1062,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 34.29 0)
+			(at 27.94 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2348,7 +1071,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 34.29 0)
+			(at 27.94 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2357,7 +1080,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 25.4 34.29 0)
+			(at 27.94 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2379,7 +1102,7 @@
 	)
 	(symbol
 		(lib_id "Device:FerriteBead_Small")
-		(at 226.06 91.44 0)
+		(at 176.53 93.98 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2387,7 +1110,7 @@
 		(dnp no)
 		(uuid "68ff63c6-f327-45bb-a6da-2d9437fdadb8")
 		(property "Reference" "FB1"
-			(at 227.33 90.17 0)
+			(at 177.8 92.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2396,7 +1119,7 @@
 			)
 		)
 		(property "Value" "220Ohm @ 100MHz"
-			(at 227.33 93.98 0)
+			(at 177.8 96.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2405,7 +1128,7 @@
 			)
 		)
 		(property "Footprint" "Inductor_SMD:L_0805_2012Metric_Pad1.05x1.20mm_HandSolder"
-			(at 224.282 91.44 90)
+			(at 174.752 93.98 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2414,7 +1137,7 @@
 			)
 		)
 		(property "Datasheet" "https://robu.in/wp-content/uploads/2024/07/C88994.pdf"
-			(at 226.06 91.44 0)
+			(at 176.53 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2423,7 +1146,7 @@
 			)
 		)
 		(property "Description" "Ferrite bead, small symbol"
-			(at 226.06 91.44 0)
+			(at 176.53 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2448,7 +1171,7 @@
 	)
 	(symbol
 		(lib_id "Device:C_Small")
-		(at 179.07 104.14 0)
+		(at 129.54 106.68 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2456,7 +1179,7 @@
 		(dnp no)
 		(uuid "840c88a6-157d-46d8-94f1-82636f0499f1")
 		(property "Reference" "C1"
-			(at 180.34 101.6 0)
+			(at 130.81 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2465,7 +1188,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 180.34 106.68 0)
+			(at 130.81 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2474,7 +1197,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 179.07 104.14 0)
+			(at 129.54 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2483,7 +1206,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 179.07 104.14 0)
+			(at 129.54 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2492,7 +1215,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor, small symbol"
-			(at 179.07 104.14 0)
+			(at 129.54 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2517,7 +1240,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 179.07 110.49 0)
+		(at 129.54 113.03 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2526,7 +1249,7 @@
 		(fields_autoplaced yes)
 		(uuid "8bd918f6-dea4-4a44-a338-f269fbcd9d06")
 		(property "Reference" "#PWR02"
-			(at 179.07 116.84 0)
+			(at 129.54 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2535,7 +1258,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 179.07 115.57 0)
+			(at 129.54 118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2543,7 +1266,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 179.07 110.49 0)
+			(at 129.54 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2552,7 +1275,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 179.07 110.49 0)
+			(at 129.54 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2561,7 +1284,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 179.07 110.49 0)
+			(at 129.54 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2582,140 +1305,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:VCC")
-		(at 105.41 86.36 270)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "95431191-2206-4610-a774-363f374a3fee")
-		(property "Reference" "#PWR026"
-			(at 101.6 86.36 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "VCC"
-			(at 109.22 86.3599 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" ""
-			(at 105.41 86.36 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 105.41 86.36 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 105.41 86.36 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "1a1e30f7-3a95-4b00-9705-e791e02e9b43")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR026")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:GND")
-		(at 74.93 128.27 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "a7769180-8e10-4529-bf14-d18203bda983")
-		(property "Reference" "#PWR018"
-			(at 74.93 134.62 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 74.93 132.08 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 74.93 128.27 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 74.93 128.27 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 74.93 128.27 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "5d39cffc-1c10-417d-9efc-f6d736acbb13")
-		)
-		(instances
-			(project "HW"
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR018")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 218.44 110.49 0)
+		(at 168.91 113.03 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2724,7 +1315,7 @@
 		(fields_autoplaced yes)
 		(uuid "be583dc5-1a34-48f8-9aff-e9e6bf79f9e1")
 		(property "Reference" "#PWR03"
-			(at 218.44 116.84 0)
+			(at 168.91 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2733,7 +1324,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 218.44 115.57 0)
+			(at 168.91 118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2741,7 +1332,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 218.44 110.49 0)
+			(at 168.91 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2750,7 +1341,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 218.44 110.49 0)
+			(at 168.91 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2759,7 +1350,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 218.44 110.49 0)
+			(at 168.91 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2780,188 +1371,8 @@
 		)
 	)
 	(symbol
-		(lib_id "Connector:USB_C_Receptacle_USB2.0_16P")
-		(at 82.55 101.6 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "d87a5339-2bde-47bd-b2bd-8f67b44aefee")
-		(property "Reference" "J1"
-			(at 91.44 81.28 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "USB Type C Connector"
-			(at 95.25 121.92 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 86.36 101.6 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
-			(at 86.36 101.6 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "USB 2.0-only 16P Type-C Receptacle connector"
-			(at 82.55 101.6 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "B9"
-			(uuid "3f44cee3-52d1-432e-842a-97f265bce31c")
-		)
-		(pin "B1"
-			(uuid "bcecdc74-fce1-456f-bd54-40e0de593676")
-		)
-		(pin "A4"
-			(uuid "0c1c7f0d-b3fa-4e00-90c9-5d05459836e6")
-		)
-		(pin "B4"
-			(uuid "edea9345-dd3a-4fb2-8d14-af23759490fa")
-		)
-		(pin "A5"
-			(uuid "f2d42ad6-1b68-42de-a25c-9ce1c71ab218")
-		)
-		(pin "B8"
-			(uuid "34a8e103-76c0-4f93-b268-69ee3d4453dd")
-		)
-		(pin "B6"
-			(uuid "ccb525e3-3a81-4ff7-83c3-a0d992c8e790")
-		)
-		(pin "A12"
-			(uuid "cf76b54a-b705-4e47-8a9b-774b9b4dcc1c")
-		)
-		(pin "B12"
-			(uuid "7e325ae5-0902-43c9-bb07-f62ce914f832")
-		)
-		(pin "S1"
-			(uuid "4e889e66-924f-499d-b139-662ba7e3e042")
-		)
-		(pin "A1"
-			(uuid "a4f71d49-a38f-44f9-89c4-7ad64f7bbda2")
-		)
-		(pin "A7"
-			(uuid "08325ef9-b457-40ac-ac0e-3ab0b0b5d09f")
-		)
-		(pin "A9"
-			(uuid "0e1b8ce3-5550-41d5-8e01-ceb7b614293a")
-		)
-		(pin "B5"
-			(uuid "e4d650a2-5cb1-4bd0-94e6-3343292ff7b1")
-		)
-		(pin "B7"
-			(uuid "79b7dd5a-975e-4f63-b475-917ff704936d")
-		)
-		(pin "A6"
-			(uuid "c8ab5353-f0e4-482e-a057-fff97d69b56f")
-		)
-		(pin "A8"
-			(uuid "be7dae75-412b-48cc-bb57-d6944074dd95")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "J1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 113.03 93.98 90)
-		(mirror x)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "d9514cba-8fa6-455f-926e-02aa139d6616")
-		(property "Reference" "R3"
-			(at 113.03 100.33 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "5.1k"
-			(at 113.03 97.79 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 113.03 92.202 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 113.03 93.98 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 113.03 93.98 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "106dcb14-7bf2-48c8-9061-ee2e0791d8d8")
-		)
-		(pin "2"
-			(uuid "8028f3f6-d79c-45a2-9402-316fffd4047c")
-		)
-		(instances
-			(project ""
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "R3")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:GND")
-		(at 199.39 110.49 0)
+		(at 149.86 113.03 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2970,7 +1381,7 @@
 		(fields_autoplaced yes)
 		(uuid "e0f913f9-6f67-4efb-a60e-4cc90dd9b3d3")
 		(property "Reference" "#PWR01"
-			(at 199.39 116.84 0)
+			(at 149.86 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2979,7 +1390,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 199.39 115.57 0)
+			(at 149.86 118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2987,7 +1398,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 199.39 110.49 0)
+			(at 149.86 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2996,7 +1407,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 199.39 110.49 0)
+			(at 149.86 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3005,7 +1416,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 199.39 110.49 0)
+			(at 149.86 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3027,7 +1438,7 @@
 	)
 	(symbol
 		(lib_id "power:VCC")
-		(at 166.37 99.06 90)
+		(at 116.84 101.6 90)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -3036,7 +1447,7 @@
 		(dnp no)
 		(uuid "f12a3c19-8408-4507-b8c1-cf43d02d9e34")
 		(property "Reference" "#PWR027"
-			(at 170.18 99.06 0)
+			(at 120.65 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3045,7 +1456,7 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 162.56 99.0599 90)
+			(at 113.03 101.5999 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3054,7 +1465,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 166.37 99.06 0)
+			(at 116.84 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3063,7 +1474,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 166.37 99.06 0)
+			(at 116.84 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3072,7 +1483,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 166.37 99.06 0)
+			(at 116.84 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -296,6 +296,313 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "Device:LED"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Regulator_Linear:LM1117MP-3.3"
 			(exclude_from_sim no)
 			(in_bom yes)
@@ -672,6 +979,19 @@
 		)
 		(uuid "1e021d74-c193-45bd-9b89-7c422f254d45")
 	)
+	(text "Power Led"
+		(exclude_from_sim no)
+		(at 266.446 53.086 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "652a3ee7-cbc3-49f8-9451-00792d484900")
+	)
 	(junction
 		(at 168.91 101.6)
 		(diameter 0)
@@ -750,6 +1070,17 @@
 		)
 		(uuid "42b96f0b-7766-4948-bbfb-b251eec4a03c")
 	)
+	(polyline
+		(pts
+			(xy 245.11 12.7) (xy 245.11 21.59)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "4465a989-fb69-49f0-a82d-bc5d9abe622c")
+	)
 	(wire
 		(pts
 			(xy 149.86 109.22) (xy 149.86 113.03)
@@ -800,6 +1131,27 @@
 		)
 		(uuid "9c95b28b-9026-437c-98a9-310ec4cfbb61")
 	)
+	(wire
+		(pts
+			(xy 265.43 22.86) (xy 265.43 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a4c1529b-fefb-4671-973d-40491c4814a3")
+	)
+	(polyline
+		(pts
+			(xy 245.11 21.59) (xy 245.11 60.96)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "a7dafe16-d3d4-41e3-acf6-1bdbc67d496e")
+	)
 	(polyline
 		(pts
 			(xy 40.64 38.1) (xy 40.64 11.43)
@@ -810,6 +1162,16 @@
 			(color 72 72 72 1)
 		)
 		(uuid "acd98e81-6fcc-4a0a-beaf-3fb110dfa060")
+	)
+	(wire
+		(pts
+			(xy 265.43 33.02) (xy 265.43 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b1696361-fc9d-44ad-b1df-49a8fdb7a167")
 	)
 	(polyline
 		(pts
@@ -844,6 +1206,16 @@
 	)
 	(wire
 		(pts
+			(xy 129.54 86.36) (xy 129.54 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db3d5af4-0d06-4534-aa56-c6cb8715e69e")
+	)
+	(wire
+		(pts
 			(xy 168.91 101.6) (xy 176.53 101.6)
 		)
 		(stroke
@@ -852,15 +1224,16 @@
 		)
 		(uuid "dce745c4-461d-401a-a29e-ef68b69bd844")
 	)
-	(wire
+	(polyline
 		(pts
-			(xy 116.84 101.6) (xy 129.54 101.6)
+			(xy 284.48 60.96) (xy 245.11 60.96)
 		)
 		(stroke
 			(width 0)
-			(type default)
+			(type dash)
+			(color 72 72 72 1)
 		)
-		(uuid "ea0a56ea-ac29-4126-8aee-09ab9c8fbf88")
+		(uuid "e6822d60-2a0e-40da-b74b-12843ed410be")
 	)
 	(hierarchical_label "3V3_VCCA"
 		(shape passive)
@@ -1170,6 +1543,208 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R")
+		(at 265.43 39.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6ef5e22b-684c-40d3-ad48-28b36b75217f")
+		(property "Reference" "R2"
+			(at 267.97 38.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "150"
+			(at 267.97 40.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 263.652 39.37 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 265.43 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 265.43 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "00aec166-b44a-476e-aa32-6b8f69e4252a")
+		)
+		(pin "2"
+			(uuid "ad2c462a-3611-4a44-8ece-a40ff1515599")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 265.43 43.18 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7a12e358-f1ac-4e45-9814-23b17c7b000c")
+		(property "Reference" "#PWR037"
+			(at 265.43 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 265.43 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 265.43 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 265.43 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 265.43 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c953ce9-fec8-4fa7-a538-fe9d6ae6e943")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR037")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 265.43 22.86 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7bccaa12-18a5-493a-b57d-f2677039ae8f")
+		(property "Reference" "#PWR036"
+			(at 265.43 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 265.43 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 265.43 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 265.43 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 265.43 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0fc2d4c3-78cd-404d-a181-806efd6c0493")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR036")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:C_Small")
 		(at 129.54 106.68 0)
 		(unit 1)
@@ -1233,6 +1808,85 @@
 			(project ""
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
 					(reference "C1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 265.43 29.21 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8455eb92-9069-472e-b8d2-0ed3600c79d7")
+		(property "Reference" "D1"
+			(at 269.24 29.5274 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED"
+			(at 269.24 32.0674 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
+			(at 265.43 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 265.43 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 265.43 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 265.43 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc22c2de-5f07-4dae-8807-9f1ff152e06f")
+		)
+		(pin "2"
+			(uuid "e94d2bb0-4949-4e7b-b242-7776163ff4c6")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "D1")
 					(unit 1)
 				)
 			)
@@ -1438,8 +2092,8 @@
 	)
 	(symbol
 		(lib_id "power:VCC")
-		(at 116.84 101.6 90)
-		(mirror x)
+		(at 129.54 86.36 0)
+		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1447,7 +2101,7 @@
 		(dnp no)
 		(uuid "f12a3c19-8408-4507-b8c1-cf43d02d9e34")
 		(property "Reference" "#PWR027"
-			(at 120.65 101.6 0)
+			(at 129.54 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1456,7 +2110,7 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 113.03 101.5999 90)
+			(at 129.5401 82.55 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1465,7 +2119,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 116.84 101.6 0)
+			(at 129.54 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1474,7 +2128,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 116.84 101.6 0)
+			(at 129.54 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1483,7 +2137,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 116.84 101.6 0)
+			(at 129.54 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -863,7 +863,7 @@
 		(uuid "ea0a56ea-ac29-4126-8aee-09ab9c8fbf88")
 	)
 	(hierarchical_label "3V3_VCCA"
-		(shape output)
+		(shape passive)
 		(at 180.34 86.36 0)
 		(effects
 			(font
@@ -874,7 +874,7 @@
 		(uuid "4e8422c5-25ba-4d5f-962d-423a11ef7610")
 	)
 	(hierarchical_label "3V3_VCC"
-		(shape output)
+		(shape passive)
 		(at 180.34 101.6 0)
 		(effects
 			(font
@@ -885,7 +885,7 @@
 		(uuid "dc7e80f9-fd1c-4c88-a6d8-bc8504069dce")
 	)
 	(hierarchical_label "USB_VCC"
-		(shape input)
+		(shape passive)
 		(at 26.67 34.29 180)
 		(effects
 			(font

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -993,6 +993,130 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Regulator_Linear:LM1117MP-3.3"
 			(exclude_from_sim no)
 			(in_bom yes)
@@ -1231,60 +1355,185 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "power:VCC"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "VCC"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"VCC\""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "VCC_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "VCC_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "Power Out\n"
+		(exclude_from_sim no)
+		(at 21.082 15.748 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.1588)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "1e021d74-c193-45bd-9b89-7c422f254d45")
 	)
 	(junction
-		(at 154.94 91.44)
+		(at 218.44 99.06)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "374f4c9f-e852-4ee2-9efe-f4140cd71971")
 	)
 	(junction
-		(at 162.56 91.44)
+		(at 97.79 100.33)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "63e3be57-075c-467a-86b2-e2b779ab37b4")
+	)
+	(junction
+		(at 226.06 99.06)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "bc3011ec-c9a9-4368-9d7a-2a95989f7526")
 	)
 	(junction
-		(at 115.57 91.44)
+		(at 179.07 99.06)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "be55d9e0-e73a-4613-8773-ad5bd5934cb8")
 	)
-	(no_connect
-		(at 46.99 41.91)
-		(uuid "218998ff-e77d-437a-a664-b2033aeb9a35")
+	(junction
+		(at 97.79 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f877545b-e035-46ef-9450-110450ce7b83")
 	)
 	(no_connect
-		(at 46.99 52.07)
+		(at 97.79 114.3)
 		(uuid "651f93cf-5fec-41e4-8c9c-c4d6b1efac64")
 	)
 	(no_connect
-		(at 46.99 39.37)
-		(uuid "7db9ebe2-0764-46d3-875c-c738ac471bd4")
-	)
-	(no_connect
-		(at 46.99 31.75)
-		(uuid "c0839df0-4e01-4a1c-b243-b3289e57816e")
-	)
-	(no_connect
-		(at 46.99 36.83)
-		(uuid "c850388c-50ec-4558-824d-19f853a7deb0")
-	)
-	(no_connect
-		(at 46.99 29.21)
-		(uuid "d9bca6e8-35d4-46ce-894a-65a382936c0c")
-	)
-	(no_connect
-		(at 46.99 54.61)
+		(at 97.79 116.84)
 		(uuid "e66dadbb-cebd-460a-b609-03383928787a")
-	)
-	(no_connect
-		(at 46.99 44.45)
-		(uuid "ed04d055-8294-480d-81f5-89f2e94bf382")
 	)
 	(wire
 		(pts
-			(xy 154.94 91.44) (xy 154.94 92.71)
+			(xy 218.44 99.06) (xy 218.44 100.33)
 		)
 		(stroke
 			(width 0)
@@ -1294,7 +1543,17 @@
 	)
 	(wire
 		(pts
-			(xy 115.57 99.06) (xy 115.57 102.87)
+			(xy 35.56 27.94) (xy 35.56 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "18d9bc00-ece1-484d-939b-5491e9c91c76")
+	)
+	(wire
+		(pts
+			(xy 179.07 106.68) (xy 179.07 110.49)
 		)
 		(stroke
 			(width 0)
@@ -1304,7 +1563,7 @@
 	)
 	(wire
 		(pts
-			(xy 31.75 62.23) (xy 31.75 66.04)
+			(xy 82.55 124.46) (xy 82.55 128.27)
 		)
 		(stroke
 			(width 0)
@@ -1314,7 +1573,17 @@
 	)
 	(wire
 		(pts
-			(xy 162.56 81.28) (xy 162.56 76.2)
+			(xy 123.19 91.44) (xy 127 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "25f70f45-0a9e-42d4-8f37-7a1124ef9f8f")
+	)
+	(wire
+		(pts
+			(xy 226.06 88.9) (xy 226.06 83.82)
 		)
 		(stroke
 			(width 0)
@@ -1324,7 +1593,17 @@
 	)
 	(wire
 		(pts
-			(xy 162.56 86.36) (xy 162.56 91.44)
+			(xy 97.79 100.33) (xy 97.79 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "301bce74-306f-4ae9-b372-6bcc652eeff2")
+	)
+	(wire
+		(pts
+			(xy 226.06 93.98) (xy 226.06 99.06)
 		)
 		(stroke
 			(width 0)
@@ -1334,7 +1613,47 @@
 	)
 	(wire
 		(pts
-			(xy 135.89 99.06) (xy 135.89 102.87)
+			(xy 97.79 105.41) (xy 97.79 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "338b1bce-0b6f-4142-92ff-9f72356855f8")
+	)
+	(wire
+		(pts
+			(xy 116.84 93.98) (xy 120.65 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f7e0693-993c-41c4-96a4-f43a117943e6")
+	)
+	(wire
+		(pts
+			(xy 25.4 34.29) (xy 35.56 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "42b96f0b-7766-4948-bbfb-b251eec4a03c")
+	)
+	(wire
+		(pts
+			(xy 120.65 93.98) (xy 120.65 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "493e57a1-50db-49ef-95d8-49cbca54ff57")
+	)
+	(wire
+		(pts
+			(xy 199.39 106.68) (xy 199.39 110.49)
 		)
 		(stroke
 			(width 0)
@@ -1344,7 +1663,27 @@
 	)
 	(wire
 		(pts
-			(xy 162.56 76.2) (xy 166.37 76.2)
+			(xy 97.79 104.14) (xy 97.79 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c2d54e4-03a5-48c8-a468-8110ede7ee63")
+	)
+	(wire
+		(pts
+			(xy 97.79 99.06) (xy 97.79 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d4387a9-5ff1-4dee-bfa9-ef5a64460d0e")
+	)
+	(wire
+		(pts
+			(xy 226.06 83.82) (xy 229.87 83.82)
 		)
 		(stroke
 			(width 0)
@@ -1354,7 +1693,7 @@
 	)
 	(wire
 		(pts
-			(xy 162.56 91.44) (xy 166.37 91.44)
+			(xy 226.06 99.06) (xy 229.87 99.06)
 		)
 		(stroke
 			(width 0)
@@ -1364,7 +1703,17 @@
 	)
 	(wire
 		(pts
-			(xy 24.13 62.23) (xy 24.13 66.04)
+			(xy 97.79 105.41) (xy 105.41 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "635befa3-ea10-4778-9770-065170cb7a71")
+	)
+	(wire
+		(pts
+			(xy 74.93 124.46) (xy 74.93 128.27)
 		)
 		(stroke
 			(width 0)
@@ -1374,7 +1723,7 @@
 	)
 	(wire
 		(pts
-			(xy 154.94 97.79) (xy 154.94 102.87)
+			(xy 218.44 105.41) (xy 218.44 110.49)
 		)
 		(stroke
 			(width 0)
@@ -1384,7 +1733,7 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 91.44) (xy 154.94 91.44)
+			(xy 207.01 99.06) (xy 218.44 99.06)
 		)
 		(stroke
 			(width 0)
@@ -1394,7 +1743,17 @@
 	)
 	(wire
 		(pts
-			(xy 59.69 24.13) (xy 46.99 24.13)
+			(xy 97.79 93.98) (xy 109.22 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a9220753-33c8-46c4-b1c9-c88731ddeb91")
+	)
+	(wire
+		(pts
+			(xy 105.41 86.36) (xy 97.79 86.36)
 		)
 		(stroke
 			(width 0)
@@ -1402,9 +1761,41 @@
 		)
 		(uuid "ab6edf25-542d-498d-baa8-f5654dca5f9d")
 	)
+	(polyline
+		(pts
+			(xy 40.64 38.1) (xy 40.64 11.43)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "acd98e81-6fcc-4a0a-beaf-3fb110dfa060")
+	)
 	(wire
 		(pts
-			(xy 115.57 91.44) (xy 115.57 93.98)
+			(xy 97.79 91.44) (xy 115.57 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b9cd2588-cf25-4ec8-8c21-ee48e9429521")
+	)
+	(polyline
+		(pts
+			(xy 12.7 38.1) (xy 40.64 38.1)
+		)
+		(stroke
+			(width 0)
+			(type dash)
+			(color 72 72 72 1)
+		)
+		(uuid "bc70a64c-51d2-4afd-b227-f3042ec9dbb1")
+	)
+	(wire
+		(pts
+			(xy 179.07 99.06) (xy 179.07 101.6)
 		)
 		(stroke
 			(width 0)
@@ -1414,7 +1805,7 @@
 	)
 	(wire
 		(pts
-			(xy 128.27 91.44) (xy 115.57 91.44)
+			(xy 191.77 99.06) (xy 179.07 99.06)
 		)
 		(stroke
 			(width 0)
@@ -1424,7 +1815,17 @@
 	)
 	(wire
 		(pts
-			(xy 154.94 91.44) (xy 162.56 91.44)
+			(xy 127 91.44) (xy 127 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da8da93b-e69b-42bf-8350-db598431aa1c")
+	)
+	(wire
+		(pts
+			(xy 218.44 99.06) (xy 226.06 99.06)
 		)
 		(stroke
 			(width 0)
@@ -1434,7 +1835,7 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 91.44) (xy 115.57 91.44)
+			(xy 166.37 99.06) (xy 179.07 99.06)
 		)
 		(stroke
 			(width 0)
@@ -1442,29 +1843,19 @@
 		)
 		(uuid "ea0a56ea-ac29-4126-8aee-09ab9c8fbf88")
 	)
-	(label "USB_VCC"
-		(at 102.87 91.44 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
+	(wire
+		(pts
+			(xy 97.79 100.33) (xy 105.41 100.33)
 		)
-		(uuid "835f9438-1461-43e1-9352-2e26ff9c3e3f")
-	)
-	(label "USB_VCC"
-		(at 59.69 24.13 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "8ffbcc92-ec9d-41e5-88c9-dc45efb8b858")
+		(uuid "f80ec31d-db0d-4abe-91a2-9b76b2cef664")
 	)
 	(hierarchical_label "3V3_VCCA"
 		(shape output)
-		(at 166.37 76.2 0)
+		(at 229.87 83.82 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1475,7 +1866,7 @@
 	)
 	(hierarchical_label "3V3_VCC"
 		(shape output)
-		(at 166.37 91.44 0)
+		(at 229.87 99.06 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1484,9 +1875,109 @@
 		)
 		(uuid "dc7e80f9-fd1c-4c88-a6d8-bc8504069dce")
 	)
+	(hierarchical_label "D-"
+		(shape bidirectional)
+		(at 105.41 105.41 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e1326f4c-67f4-4864-b8d8-3e9cd208201b")
+	)
+	(hierarchical_label "D+"
+		(shape bidirectional)
+		(at 105.41 100.33 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e3a04937-5736-4bfb-8fd9-2e980c3c8e9e")
+	)
+	(hierarchical_label "USB_VCC"
+		(shape output)
+		(at 35.56 27.94 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "eea4b2f5-7699-4f6a-a763-54302c808bc0")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 119.38 91.44 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0a7f8205-cb9b-4a21-b8ee-c32363a66fac")
+		(property "Reference" "R2"
+			(at 119.38 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 119.38 87.63 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 93.218 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 119.38 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "87060908-e108-4b57-b73b-9d0a6d5c50a3")
+		)
+		(pin "1"
+			(uuid "791db98f-63f8-41d0-ad0d-a4a071c56b75")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
 	(symbol
 		(lib_id "Regulator_Linear:LM1117MP-3.3")
-		(at 135.89 91.44 0)
+		(at 199.39 99.06 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1494,7 +1985,7 @@
 		(dnp no)
 		(uuid "0bca257c-9d96-4df8-af63-d39dd161329f")
 		(property "Reference" "U3"
-			(at 139.7 87.63 0)
+			(at 203.2 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1502,7 +1993,7 @@
 			)
 		)
 		(property "Value" "LM1117MP-3.3"
-			(at 143.51 97.79 0)
+			(at 207.01 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1510,7 +2001,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
-			(at 135.89 91.44 0)
+			(at 199.39 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1519,7 +2010,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/lm1117.pdf"
-			(at 135.89 91.44 0)
+			(at 199.39 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1528,7 +2019,7 @@
 			)
 		)
 		(property "Description" "800mA Low-Dropout Linear Regulator, 3.3V fixed output, SOT-223"
-			(at 135.89 91.44 0)
+			(at 199.39 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1555,8 +2046,74 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 120.65 96.52 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3f6bc562-9d34-4fa8-865b-42e3b6aab824")
+		(property "Reference" "#PWR024"
+			(at 120.65 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 120.65 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 120.65 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 120.65 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 120.65 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "37bccff7-7dfc-42a3-adb6-2a526244f409")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR024")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:C_Small")
-		(at 154.94 95.25 0)
+		(at 218.44 102.87 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1564,7 +2121,7 @@
 		(dnp no)
 		(uuid "462b8421-9a2c-472e-a4a4-62251f915fcb")
 		(property "Reference" "C2"
-			(at 156.21 92.71 0)
+			(at 219.71 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1573,7 +2130,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 156.21 97.79 0)
+			(at 219.71 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1582,7 +2139,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 154.94 95.25 0)
+			(at 218.44 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1591,7 +2148,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 154.94 95.25 0)
+			(at 218.44 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1600,7 +2157,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor, small symbol"
-			(at 154.94 95.25 0)
+			(at 218.44 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1625,7 +2182,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 31.75 66.04 0)
+		(at 82.55 128.27 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1633,7 +2190,7 @@
 		(dnp no)
 		(uuid "4bbfee0f-4141-4876-a671-ada67be7a61f")
 		(property "Reference" "#PWR017"
-			(at 31.75 72.39 0)
+			(at 82.55 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1642,7 +2199,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 31.75 69.85 0)
+			(at 82.55 132.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1650,7 +2207,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 31.75 66.04 0)
+			(at 82.55 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1659,7 +2216,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 31.75 66.04 0)
+			(at 82.55 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1668,7 +2225,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 31.75 66.04 0)
+			(at 82.55 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1689,8 +2246,140 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 127 96.52 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4bea2cdc-6222-49d7-ab9d-ee490ab17234")
+		(property "Reference" "#PWR023"
+			(at 127 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 127 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 127 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 127 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 127 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "34d5b0d5-98f1-4755-8241-a44351b4a7f1")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR023")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 25.4 34.29 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "58fba050-cf77-4c14-b8d8-6d33464e2fd4")
+		(property "Reference" "#PWR028"
+			(at 29.21 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 21.59 34.2899 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 25.4 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 25.4 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 25.4 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "35d90227-17d1-47c3-b1aa-4de2d3a1e1d1")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR028")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:FerriteBead_Small")
-		(at 162.56 83.82 0)
+		(at 226.06 91.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1698,7 +2387,7 @@
 		(dnp no)
 		(uuid "68ff63c6-f327-45bb-a6da-2d9437fdadb8")
 		(property "Reference" "FB1"
-			(at 163.83 82.55 0)
+			(at 227.33 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1707,7 +2396,7 @@
 			)
 		)
 		(property "Value" "220Ohm @ 100MHz"
-			(at 163.83 86.36 0)
+			(at 227.33 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1716,7 +2405,7 @@
 			)
 		)
 		(property "Footprint" "Inductor_SMD:L_0805_2012Metric_Pad1.05x1.20mm_HandSolder"
-			(at 160.782 83.82 90)
+			(at 224.282 91.44 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1725,7 +2414,7 @@
 			)
 		)
 		(property "Datasheet" "https://robu.in/wp-content/uploads/2024/07/C88994.pdf"
-			(at 162.56 83.82 0)
+			(at 226.06 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1734,7 +2423,7 @@
 			)
 		)
 		(property "Description" "Ferrite bead, small symbol"
-			(at 162.56 83.82 0)
+			(at 226.06 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1759,7 +2448,7 @@
 	)
 	(symbol
 		(lib_id "Device:C_Small")
-		(at 115.57 96.52 0)
+		(at 179.07 104.14 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1767,7 +2456,7 @@
 		(dnp no)
 		(uuid "840c88a6-157d-46d8-94f1-82636f0499f1")
 		(property "Reference" "C1"
-			(at 116.84 93.98 0)
+			(at 180.34 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1776,7 +2465,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 116.84 99.06 0)
+			(at 180.34 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1785,7 +2474,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 115.57 96.52 0)
+			(at 179.07 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1794,7 +2483,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 115.57 96.52 0)
+			(at 179.07 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1803,7 +2492,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor, small symbol"
-			(at 115.57 96.52 0)
+			(at 179.07 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1828,7 +2517,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 115.57 102.87 0)
+		(at 179.07 110.49 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1837,7 +2526,7 @@
 		(fields_autoplaced yes)
 		(uuid "8bd918f6-dea4-4a44-a338-f269fbcd9d06")
 		(property "Reference" "#PWR02"
-			(at 115.57 109.22 0)
+			(at 179.07 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1846,7 +2535,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 115.57 107.95 0)
+			(at 179.07 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1854,7 +2543,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 115.57 102.87 0)
+			(at 179.07 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1863,7 +2552,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 115.57 102.87 0)
+			(at 179.07 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1872,7 +2561,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 115.57 102.87 0)
+			(at 179.07 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1893,16 +2582,17 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 24.13 66.04 0)
+		(lib_id "power:VCC")
+		(at 105.41 86.36 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a7769180-8e10-4529-bf14-d18203bda983")
-		(property "Reference" "#PWR018"
-			(at 24.13 72.39 0)
+		(fields_autoplaced yes)
+		(uuid "95431191-2206-4610-a774-363f374a3fee")
+		(property "Reference" "#PWR026"
+			(at 101.6 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1910,16 +2600,17 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "GND"
-			(at 24.13 69.85 0)
+		(property "Value" "VCC"
+			(at 109.22 86.3599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Footprint" ""
-			(at 24.13 66.04 0)
+			(at 105.41 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1928,7 +2619,72 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 24.13 66.04 0)
+			(at 105.41 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 105.41 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1a1e30f7-3a95-4b00-9705-e791e02e9b43")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR026")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 74.93 128.27 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a7769180-8e10-4529-bf14-d18203bda983")
+		(property "Reference" "#PWR018"
+			(at 74.93 134.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 74.93 132.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 74.93 128.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 74.93 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1937,7 +2693,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 24.13 66.04 0)
+			(at 74.93 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1959,7 +2715,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 154.94 102.87 0)
+		(at 218.44 110.49 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1968,7 +2724,7 @@
 		(fields_autoplaced yes)
 		(uuid "be583dc5-1a34-48f8-9aff-e9e6bf79f9e1")
 		(property "Reference" "#PWR03"
-			(at 154.94 109.22 0)
+			(at 218.44 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1977,7 +2733,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 154.94 107.95 0)
+			(at 218.44 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1985,7 +2741,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 154.94 102.87 0)
+			(at 218.44 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1994,7 +2750,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 154.94 102.87 0)
+			(at 218.44 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2003,7 +2759,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 154.94 102.87 0)
+			(at 218.44 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2025,7 +2781,7 @@
 	)
 	(symbol
 		(lib_id "Connector:USB_C_Receptacle_USB2.0_16P")
-		(at 31.75 39.37 0)
+		(at 82.55 101.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2033,7 +2789,7 @@
 		(dnp no)
 		(uuid "d87a5339-2bde-47bd-b2bd-8f67b44aefee")
 		(property "Reference" "J1"
-			(at 40.64 19.05 0)
+			(at 91.44 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2041,7 +2797,7 @@
 			)
 		)
 		(property "Value" "USB Type C Connector"
-			(at 44.45 59.69 0)
+			(at 95.25 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2049,7 +2805,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 35.56 39.37 0)
+			(at 86.36 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2058,7 +2814,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
-			(at 35.56 39.37 0)
+			(at 86.36 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2067,7 +2823,7 @@
 			)
 		)
 		(property "Description" "USB 2.0-only 16P Type-C Receptacle connector"
-			(at 31.75 39.37 0)
+			(at 82.55 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2136,8 +2892,76 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R")
+		(at 113.03 93.98 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d9514cba-8fa6-455f-926e-02aa139d6616")
+		(property "Reference" "R3"
+			(at 113.03 100.33 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 113.03 97.79 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 113.03 92.202 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 113.03 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 113.03 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "106dcb14-7bf2-48c8-9061-ee2e0791d8d8")
+		)
+		(pin "2"
+			(uuid "8028f3f6-d79c-45a2-9402-316fffd4047c")
+		)
+		(instances
+			(project ""
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
-		(at 135.89 102.87 0)
+		(at 199.39 110.49 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -2146,7 +2970,7 @@
 		(fields_autoplaced yes)
 		(uuid "e0f913f9-6f67-4efb-a60e-4cc90dd9b3d3")
 		(property "Reference" "#PWR01"
-			(at 135.89 109.22 0)
+			(at 199.39 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2155,7 +2979,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 135.89 107.95 0)
+			(at 199.39 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2163,7 +2987,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 135.89 102.87 0)
+			(at 199.39 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2172,7 +2996,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 135.89 102.87 0)
+			(at 199.39 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2181,7 +3005,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 135.89 102.87 0)
+			(at 199.39 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2196,6 +3020,73 @@
 			(project ""
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
 					(reference "#PWR01")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 166.37 99.06 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f12a3c19-8408-4507-b8c1-cf43d02d9e34")
+		(property "Reference" "#PWR027"
+			(at 170.18 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 162.56 99.0599 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 166.37 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 166.37 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 166.37 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fcae792a-b867-440d-ab24-d6a0fc97392b")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR027")
 					(unit 1)
 				)
 			)

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -1248,6 +1248,17 @@
 	)
 	(hierarchical_label "3V3_VCC"
 		(shape passive)
+		(at 265.43 22.86 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ca0d50e3-28a2-4f1f-bac3-75493b87c7b4")
+	)
+	(hierarchical_label "3V3_VCC"
+		(shape passive)
 		(at 180.34 101.6 0)
 		(effects
 			(font
@@ -1561,7 +1572,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "150"
+		(property "Value" "100"
 			(at 267.97 40.6399 0)
 			(effects
 				(font
@@ -1673,72 +1684,6 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
 					(reference "#PWR037")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:VCC")
-		(at 265.43 22.86 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "7bccaa12-18a5-493a-b57d-f2677039ae8f")
-		(property "Reference" "#PWR036"
-			(at 265.43 26.67 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "VCC"
-			(at 265.43 17.78 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 265.43 22.86 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 265.43 22.86 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 265.43 22.86 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "0fc2d4c3-78cd-404d-a181-806efd6c0493")
-		)
-		(instances
-			(project "HW"
-				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR036")
 					(unit 1)
 				)
 			)

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -702,7 +702,7 @@
 	)
 	(wire
 		(pts
-			(xy 17.78 27.94) (xy 17.78 34.29)
+			(xy 26.67 34.29) (xy 33.02 34.29)
 		)
 		(stroke
 			(width 0)
@@ -742,7 +742,7 @@
 	)
 	(wire
 		(pts
-			(xy 27.94 34.29) (xy 17.78 34.29)
+			(xy 33.02 24.13) (xy 33.02 34.29)
 		)
 		(stroke
 			(width 0)
@@ -885,13 +885,13 @@
 		(uuid "dc7e80f9-fd1c-4c88-a6d8-bc8504069dce")
 	)
 	(hierarchical_label "USB_VCC"
-		(shape output)
-		(at 17.78 27.94 90)
+		(shape input)
+		(at 26.67 34.29 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
-			(justify left)
+			(justify right)
 		)
 		(uuid "eea4b2f5-7699-4f6a-a763-54302c808bc0")
 	)
@@ -1036,7 +1036,7 @@
 	)
 	(symbol
 		(lib_id "power:VCC")
-		(at 27.94 34.29 270)
+		(at 33.02 24.13 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -1044,7 +1044,7 @@
 		(dnp no)
 		(uuid "58fba050-cf77-4c14-b8d8-6d33464e2fd4")
 		(property "Reference" "#PWR028"
-			(at 24.13 34.29 0)
+			(at 33.02 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1053,7 +1053,7 @@
 			)
 		)
 		(property "Value" "VCC"
-			(at 31.75 34.2899 90)
+			(at 33.0199 20.32 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1062,7 +1062,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 27.94 34.29 0)
+			(at 33.02 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1071,7 +1071,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 27.94 34.29 0)
+			(at 33.02 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1080,7 +1080,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VCC\""
-			(at 27.94 34.29 0)
+			(at 33.02 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/~HW.kicad_sch.lck
+++ b/~HW.kicad_sch.lck
@@ -1,0 +1,1 @@
+{"hostname":"debian","username":"abinav"}


### PR DESCRIPTION
Added the FT232RL USB‑to‑UART interface IC (FT232RL) into the schematic and powered it from the 3.3 V and 5 V rails. Exposed its TTL-level RXD and TXD pins through the hierarchical sheet and connected it to the MCU

- Placed FT232RL SSOP‑28 symbol and footprint, tied VCCIO to 3.3 V, VCC to USB_VCC, and GND to ground.
- Left legacy RS‑232 control lines (DSR#, DCD#, RI#) and CBUS pins unconnected.
- Updated hierarchy:added sheet pins on USB_UART page.

This enables USB‑serial communication between host PC and STM32F030F4Px