### PR TITLE
Fix(annotation)

### DIFF
--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -863,7 +863,7 @@
         "uuid": "01550cd7-b424-469c-925b-c370f3609cd4"
       }
     ],
-    "used_designators": "SW1,R1-10,U1-5,Q1,J1-3,D1-4,C1-12,FB1-2,#PWR1-58,#FLG1-5",
+    "used_designators": "",
     "variants": []
   },
   "sheets": [

--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -863,7 +863,7 @@
         "uuid": "01550cd7-b424-469c-925b-c370f3609cd4"
       }
     ],
-    "used_designators": "#PWR62-63,J3,D4",
+    "used_designators": "SW1,R1-10,U1-5,Q1,J1-3,D1-4,C1-12,FB1-2,#PWR1-58,#FLG1-5",
     "variants": []
   },
   "sheets": [

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -3307,7 +3307,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "04997b99-bb01-4a2e-8a72-8a583b57c685")
-		(property "Reference" "#FLG02"
+		(property "Reference" "#FLG05"
 			(at 193.675 139.7 0)
 			(hide yes)
 			(show_name no)
@@ -3368,7 +3368,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#FLG02")
+					(reference "#FLG05")
 					(unit 1)
 				)
 			)
@@ -3386,7 +3386,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0d167cf5-c721-4d62-b48e-35cf1dec132e")
-		(property "Reference" "#PWR035"
+		(property "Reference" "#PWR058"
 			(at 274.32 46.99 0)
 			(hide yes)
 			(show_name no)
@@ -3446,7 +3446,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR035")
+					(reference "#PWR058")
 					(unit 1)
 				)
 			)
@@ -3463,7 +3463,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "0d308bd9-cecb-48ef-b4f2-fa875fc0a3c5")
-		(property "Reference" "R5"
+		(property "Reference" "R10"
 			(at 267.97 36.83 90)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3525,7 +3525,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "R5")
+					(reference "R10")
 					(unit 1)
 				)
 			)
@@ -3543,7 +3543,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "15c4b925-67bb-4e74-a707-79a35bc8a954")
-		(property "Reference" "U4"
+		(property "Reference" "U5"
 			(at 206.6133 82.55 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3679,7 +3679,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "U4")
+					(reference "U5")
 					(unit 1)
 				)
 			)
@@ -3697,7 +3697,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1cb0a1b1-f558-4c78-95fd-682857754097")
-		(property "Reference" "#PWR032"
+		(property "Reference" "#PWR050"
 			(at 175.26 148.59 0)
 			(hide yes)
 			(show_name no)
@@ -3757,7 +3757,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR032")
+					(reference "#PWR050")
 					(unit 1)
 				)
 			)
@@ -3775,7 +3775,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "2e01bb66-01f7-4da7-a00e-8f0f0476c8ca")
-		(property "Reference" "#PWR030"
+		(property "Reference" "#PWR056"
 			(at 232.41 24.13 0)
 			(hide yes)
 			(show_name no)
@@ -3835,7 +3835,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR030")
+					(reference "#PWR056")
 					(unit 1)
 				)
 			)
@@ -3853,7 +3853,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "2e47384f-0bba-4939-aebb-7bc9de30fd48")
-		(property "Reference" "D3"
+		(property "Reference" "D4"
 			(at 236.22 26.9874 90)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3928,7 +3928,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "D3")
+					(reference "D4")
 					(unit 1)
 				)
 			)
@@ -3945,7 +3945,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "342aeb10-0bfd-45a0-a129-74967514fbf4")
-		(property "Reference" "R4"
+		(property "Reference" "R9"
 			(at 250.19 36.83 90)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4007,7 +4007,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "R4")
+					(reference "R9")
 					(unit 1)
 				)
 			)
@@ -4025,7 +4025,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3b485926-f3fa-4703-87ea-102f6fb45a5d")
-		(property "Reference" "#PWR029"
+		(property "Reference" "#PWR055"
 			(at 213.36 24.13 0)
 			(hide yes)
 			(show_name no)
@@ -4085,7 +4085,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR029")
+					(reference "#PWR055")
 					(unit 1)
 				)
 			)
@@ -4103,7 +4103,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3fc5b8d7-c07b-4c23-a54c-53bc69f574f4")
-		(property "Reference" "#PWR034"
+		(property "Reference" "#PWR057"
 			(at 256.54 46.99 0)
 			(hide yes)
 			(show_name no)
@@ -4163,7 +4163,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR034")
+					(reference "#PWR057")
 					(unit 1)
 				)
 			)
@@ -4180,7 +4180,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "4bbfee0f-4141-4876-a671-ada67be7a61f")
-		(property "Reference" "#PWR017"
+		(property "Reference" "#PWR047"
 			(at 95.25 140.97 0)
 			(hide yes)
 			(show_name no)
@@ -4240,7 +4240,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR017")
+					(reference "#PWR047")
 					(unit 1)
 				)
 			)
@@ -4258,7 +4258,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "672a8be6-6533-4f10-8063-7fbeab0486aa")
-		(property "Reference" "#PWR026"
+		(property "Reference" "#PWR048"
 			(at 111.76 85.09 0)
 			(hide yes)
 			(show_name no)
@@ -4318,7 +4318,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR026")
+					(reference "#PWR048")
 					(unit 1)
 				)
 			)
@@ -4336,7 +4336,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7abd2af0-feae-4957-9061-75c61bea0233")
-		(property "Reference" "#PWR025"
+		(property "Reference" "#PWR049"
 			(at 143.51 106.68 0)
 			(hide yes)
 			(show_name no)
@@ -4396,7 +4396,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR025")
+					(reference "#PWR049")
 					(unit 1)
 				)
 			)
@@ -4495,7 +4495,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "89451875-5cdb-4488-8520-6e09b8f34260")
-		(property "Reference" "R3"
+		(property "Reference" "R7"
 			(at 215.9 35.5599 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4559,7 +4559,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "R3")
+					(reference "R7")
 					(unit 1)
 				)
 			)
@@ -4577,7 +4577,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9483813b-1772-4181-ba5c-d300c40bf602")
-		(property "Reference" "R6"
+		(property "Reference" "R8"
 			(at 234.95 35.5599 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4641,7 +4641,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "R6")
+					(reference "R8")
 					(unit 1)
 				)
 			)
@@ -4659,7 +4659,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "94ee5ef2-5a94-4903-bb92-702739feef33")
-		(property "Reference" "D2"
+		(property "Reference" "D3"
 			(at 217.17 26.9874 90)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4734,7 +4734,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "D2")
+					(reference "D3")
 					(unit 1)
 				)
 			)
@@ -4752,7 +4752,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "979b1d0d-b8e8-4a08-ae39-bc913f1c6fb9")
-		(property "Reference" "#PWR028"
+		(property "Reference" "#PWR053"
 			(at 204.47 82.55 0)
 			(hide yes)
 			(show_name no)
@@ -4812,7 +4812,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR028")
+					(reference "#PWR053")
 					(unit 1)
 				)
 			)
@@ -4829,7 +4829,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "a7769180-8e10-4529-bf14-d18203bda983")
-		(property "Reference" "#PWR018"
+		(property "Reference" "#PWR046"
 			(at 87.63 140.97 0)
 			(hide yes)
 			(show_name no)
@@ -4889,7 +4889,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR018")
+					(reference "#PWR046")
 					(unit 1)
 				)
 			)
@@ -4907,7 +4907,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "bc8b059e-14e3-48a3-b08d-944f5a78758e")
-		(property "Reference" "C8"
+		(property "Reference" "C12"
 			(at 147.32 93.9799 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4971,7 +4971,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "C8")
+					(reference "C12")
 					(unit 1)
 				)
 			)
@@ -4988,7 +4988,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "d87a5339-2bde-47bd-b2bd-8f67b44aefee")
-		(property "Reference" "J1"
+		(property "Reference" "J3"
 			(at 104.14 87.63 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -5095,7 +5095,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "J1")
+					(reference "J3")
 					(unit 1)
 				)
 			)
@@ -5113,7 +5113,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e1399685-994c-44d8-8173-5fb6616101d6")
-		(property "Reference" "#PWR031"
+		(property "Reference" "#PWR054"
 			(at 204.47 148.59 0)
 			(hide yes)
 			(show_name no)
@@ -5173,7 +5173,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR031")
+					(reference "#PWR054")
 					(unit 1)
 				)
 			)
@@ -5191,7 +5191,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "fa2b8afd-f3ef-4bd9-bc77-c812534d082a")
-		(property "Reference" "#PWR022"
+		(property "Reference" "#PWR052"
 			(at 199.39 81.28 0)
 			(hide yes)
 			(show_name no)
@@ -5251,7 +5251,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR022")
+					(reference "#PWR052")
 					(unit 1)
 				)
 			)
@@ -5269,7 +5269,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "fed10362-c97d-4e00-a755-50e4de9b13f9")
-		(property "Reference" "#PWR033"
+		(property "Reference" "#PWR051"
 			(at 196.85 148.59 0)
 			(hide yes)
 			(show_name no)
@@ -5329,7 +5329,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
-					(reference "#PWR033")
+					(reference "#PWR051")
 					(unit 1)
 				)
 			)

--- a/fp-lib-table
+++ b/fp-lib-table
@@ -1,11 +1,4 @@
 (fp_lib_table
 	(version 7)
 	(lib (name "lcsc") (type "KiCad") (uri "${KIPRJMOD}/Libraries/Footprints") (options "") (descr ""))
-	(lib (name "footprints") (type "KiCad") (uri "/home/simson/.local/share/kicad/10.0/footprints.pretty") (options "") (descr ""))
-	(lib (name "Generated") (type "KiCad") (uri "/home/simson/.local/share/kicad/10.0/footprints/Generated.pretty") (options "") (descr ""))
-	(lib (name "Generated") (type "KiCad") (uri "/home/simson/.local/share/kicad/10.0/footprints/Generated.pretty") (options "") (descr ""))
-	(lib (name "Generated") (type "KiCad") (uri "/home/simson/.local/share/kicad/10.0/footprints/Generated.pretty") (options "") (descr ""))
-	(lib (name "Generated") (type "KiCad") (uri "/home/simson/.local/share/kicad/10.0/footprints/Generated.pretty") (options "") (descr ""))
-	(lib (name "Generated") (type "KiCad") (uri "/home/simson/.local/share/kicad/10.0/footprints/Generated.pretty") (options "") (descr ""))
-	(lib (name "Generated") (type "KiCad") (uri "/home/simson/.local/share/kicad/10.0/footprints/Generated.pretty") (options "") (descr ""))
 )

--- a/lora_module.kicad_sch
+++ b/lora_module.kicad_sch
@@ -1006,7 +1006,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "19c676a2-2327-4e33-b94a-49fa4cccd086")
-		(property "Reference" "#PWR08"
+		(property "Reference" "#PWR05"
 			(at 170.18 86.36 0)
 			(hide yes)
 			(show_name no)
@@ -1066,7 +1066,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "#PWR08")
+					(reference "#PWR05")
 					(unit 1)
 				)
 			)
@@ -1084,7 +1084,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1fe1eabb-780b-4596-91c5-3977480fac73")
-		(property "Reference" "#PWR045"
+		(property "Reference" "#PWR03"
 			(at 110.49 104.14 0)
 			(hide yes)
 			(show_name no)
@@ -1144,7 +1144,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "#PWR045")
+					(reference "#PWR03")
 					(unit 1)
 				)
 			)
@@ -1161,7 +1161,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "46462d92-35b5-4eef-8a45-39997c21fb2d")
-		(property "Reference" "C9"
+		(property "Reference" "C1"
 			(at 101.6 101.6 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -1225,7 +1225,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "C9")
+					(reference "C1")
 					(unit 1)
 				)
 			)
@@ -1243,7 +1243,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4fa14e74-ffe9-48f3-a5e2-38172e987793")
-		(property "Reference" "#PWR024"
+		(property "Reference" "#PWR06"
 			(at 170.18 125.73 0)
 			(hide yes)
 			(show_name no)
@@ -1303,7 +1303,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "#PWR024")
+					(reference "#PWR06")
 					(unit 1)
 				)
 			)
@@ -1321,7 +1321,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5ebb1c5c-407f-4311-91c1-ac07c19c82a9")
-		(property "Reference" "#PWR042"
+		(property "Reference" "#PWR02"
 			(at 100.33 114.3 0)
 			(hide yes)
 			(show_name no)
@@ -1381,7 +1381,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "#PWR042")
+					(reference "#PWR02")
 					(unit 1)
 				)
 			)
@@ -1398,7 +1398,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "6865d79d-a958-4b4a-93cd-47dcbe8646d0")
-		(property "Reference" "C10"
+		(property "Reference" "C2"
 			(at 111.76 101.6 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -1462,7 +1462,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "C10")
+					(reference "C2")
 					(unit 1)
 				)
 			)
@@ -1480,7 +1480,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6f79b1ba-49d9-4f2b-bb29-313bdae0bd51")
-		(property "Reference" "#PWR044"
+		(property "Reference" "#PWR01"
 			(at 100.33 104.14 0)
 			(hide yes)
 			(show_name no)
@@ -1540,7 +1540,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "#PWR044")
+					(reference "#PWR01")
 					(unit 1)
 				)
 			)
@@ -1558,7 +1558,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e1ee2c2d-c82c-4eb1-97f2-a6dcf7437225")
-		(property "Reference" "#PWR043"
+		(property "Reference" "#PWR04"
 			(at 110.49 114.3 0)
 			(hide yes)
 			(show_name no)
@@ -1618,7 +1618,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/2dab47df-4ca4-4373-b48e-0efc8c61f605"
-					(reference "#PWR043")
+					(reference "#PWR04")
 					(unit 1)
 				)
 			)

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -2500,7 +2500,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "197ace02-15c6-4680-8728-04150d48ee90")
-		(property "Reference" "#PWR09"
+		(property "Reference" "#PWR011"
 			(at 59.69 30.48 0)
 			(hide yes)
 			(show_name no)
@@ -2560,7 +2560,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR09")
+					(reference "#PWR011")
 					(unit 1)
 				)
 			)
@@ -2578,7 +2578,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1ad1edb5-3417-4169-baaf-e075d49e795a")
-		(property "Reference" "#PWR010"
+		(property "Reference" "#PWR016"
 			(at 154.94 134.62 0)
 			(hide yes)
 			(show_name no)
@@ -2638,7 +2638,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR010")
+					(reference "#PWR016")
 					(unit 1)
 				)
 			)
@@ -2899,7 +2899,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "2b84da0c-8fde-425f-8d62-59614ca8ecdc")
-		(property "Reference" "#PWR011"
+		(property "Reference" "#PWR018"
 			(at 223.52 35.56 0)
 			(hide yes)
 			(show_name no)
@@ -2959,7 +2959,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR011")
+					(reference "#PWR018")
 					(unit 1)
 				)
 			)
@@ -2977,7 +2977,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "31c8590b-f829-47f8-9bc6-c9814c06d8c7")
-		(property "Reference" "#PWR04"
+		(property "Reference" "#PWR07"
 			(at 21.59 31.75 0)
 			(hide yes)
 			(show_name no)
@@ -3037,7 +3037,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR04")
+					(reference "#PWR07")
 					(unit 1)
 				)
 			)
@@ -3192,7 +3192,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "41c92f8d-992e-45ca-a8b8-8245cb5a5791")
-		(property "Reference" "#PWR06"
+		(property "Reference" "#PWR08"
 			(at 21.59 44.45 0)
 			(hide yes)
 			(show_name no)
@@ -3252,7 +3252,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR06")
+					(reference "#PWR08")
 					(unit 1)
 				)
 			)
@@ -3441,7 +3441,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "72cd3963-a148-4f20-bbd4-608721091f90")
-		(property "Reference" "#PWR015"
+		(property "Reference" "#PWR014"
 			(at 69.85 44.45 0)
 			(hide yes)
 			(show_name no)
@@ -3501,7 +3501,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR015")
+					(reference "#PWR014")
 					(unit 1)
 				)
 			)
@@ -3519,7 +3519,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "740ace85-f8bc-4f9f-966c-e1220ed33f9f")
-		(property "Reference" "#PWR05"
+		(property "Reference" "#PWR09"
 			(at 34.29 31.75 0)
 			(hide yes)
 			(show_name no)
@@ -3579,7 +3579,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR05")
+					(reference "#PWR09")
 					(unit 1)
 				)
 			)
@@ -3596,7 +3596,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "9410ac9d-b6bb-41be-a5a1-f72c3c7917fc")
-		(property "Reference" "J2"
+		(property "Reference" "J1"
 			(at 217.17 33.02 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3661,7 +3661,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "J2")
+					(reference "J1")
 					(unit 1)
 				)
 			)
@@ -3679,7 +3679,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a46cdd30-aee9-42fd-8f95-8bca35f73c25")
-		(property "Reference" "#PWR040"
+		(property "Reference" "#PWR017"
 			(at 161.29 83.82 0)
 			(hide yes)
 			(show_name no)
@@ -3739,7 +3739,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR040")
+					(reference "#PWR017")
 					(unit 1)
 				)
 			)
@@ -3838,7 +3838,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "adb82a45-33a3-4a81-a1ad-09d603fddf2f")
-		(property "Reference" "#PWR016"
+		(property "Reference" "#PWR013"
 			(at 69.85 30.48 0)
 			(hide yes)
 			(show_name no)
@@ -3898,7 +3898,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR016")
+					(reference "#PWR013")
 					(unit 1)
 				)
 			)
@@ -3916,7 +3916,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c7a0af5b-a88e-4b44-9332-629f45879089")
-		(property "Reference" "#PWR014"
+		(property "Reference" "#PWR012"
 			(at 59.69 44.45 0)
 			(hide yes)
 			(show_name no)
@@ -3976,7 +3976,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR014")
+					(reference "#PWR012")
 					(unit 1)
 				)
 			)
@@ -4073,7 +4073,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d5cda0cc-68da-4b76-904e-e24387e22f6f")
-		(property "Reference" "#PWR07"
+		(property "Reference" "#PWR010"
 			(at 34.29 44.45 0)
 			(hide yes)
 			(show_name no)
@@ -4133,7 +4133,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR07")
+					(reference "#PWR010")
 					(unit 1)
 				)
 			)
@@ -4151,7 +4151,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e14838fa-abc9-4414-910f-36c630da9102")
-		(property "Reference" "#PWR039"
+		(property "Reference" "#PWR015"
 			(at 151.13 83.82 0)
 			(hide yes)
 			(show_name no)
@@ -4211,7 +4211,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR039")
+					(reference "#PWR015")
 					(unit 1)
 				)
 			)
@@ -4229,7 +4229,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ee335014-1e58-4d87-99aa-66a186fc71ad")
-		(property "Reference" "#PWR021"
+		(property "Reference" "#PWR019"
 			(at 223.52 52.07 0)
 			(hide yes)
 			(show_name no)
@@ -4289,7 +4289,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR021")
+					(reference "#PWR019")
 					(unit 1)
 				)
 			)
@@ -4306,7 +4306,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "fa9dcef2-bc5c-410b-9249-9cf1b2376390")
-		(property "Reference" "#PWR019"
+		(property "Reference" "#PWR021"
 			(at 267.97 53.34 0)
 			(hide yes)
 			(show_name no)
@@ -4366,7 +4366,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
-					(reference "#PWR019")
+					(reference "#PWR021")
 					(unit 1)
 				)
 			)

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -3288,7 +3288,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "02ea4f82-98aa-40f6-b9e3-fc688e24e091")
-		(property "Reference" "C12"
+		(property "Reference" "C8"
 			(at 80.01 92.71 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3352,7 +3352,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "C12")
+					(reference "C8")
 					(unit 1)
 				)
 			)
@@ -3370,7 +3370,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "08fd050a-c85c-4e49-97c7-33c3f0a2fd98")
-		(property "Reference" "U6"
+		(property "Reference" "U3"
 			(at 124.0633 87.63 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3455,7 +3455,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "U6")
+					(reference "U3")
 					(unit 1)
 				)
 			)
@@ -3473,7 +3473,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "107cbabd-baf2-41a5-b99d-e30d04ae1ce6")
-		(property "Reference" "J3"
+		(property "Reference" "J2"
 			(at 114.935 22.86 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3535,7 +3535,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "J3")
+					(reference "J2")
 					(unit 1)
 				)
 			)
@@ -3553,7 +3553,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "158cc4ec-99d3-4aab-8c0f-d5bc67bc10bf")
-		(property "Reference" "#PWR01"
+		(property "Reference" "#PWR038"
 			(at 187.96 91.44 0)
 			(hide yes)
 			(show_name no)
@@ -3613,7 +3613,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR01")
+					(reference "#PWR038")
 					(unit 1)
 				)
 			)
@@ -3631,7 +3631,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1968eb51-9bfa-492e-b832-748f6c695efe")
-		(property "Reference" "#PWR053"
+		(property "Reference" "#PWR023"
 			(at 25.4 124.46 0)
 			(hide yes)
 			(show_name no)
@@ -3691,7 +3691,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR053")
+					(reference "#PWR023")
 					(unit 1)
 				)
 			)
@@ -3709,7 +3709,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1abd13b3-09bb-484a-8e00-ee6bf723c797")
-		(property "Reference" "U7"
+		(property "Reference" "U4"
 			(at 213.36 92.71 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3780,7 +3780,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "U7")
+					(reference "U4")
 					(unit 1)
 				)
 			)
@@ -3798,7 +3798,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "2a75f6c8-0a8d-445b-8634-2559dd970287")
-		(property "Reference" "#PWR060"
+		(property "Reference" "#PWR026"
 			(at 46.99 90.17 0)
 			(hide yes)
 			(show_name no)
@@ -3858,7 +3858,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR060")
+					(reference "#PWR026")
 					(unit 1)
 				)
 			)
@@ -3876,7 +3876,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "306294ec-b85c-400b-b91f-ae255a0b80a9")
-		(property "Reference" "R9"
+		(property "Reference" "R2"
 			(at 27.94 110.4899 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3940,7 +3940,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "R9")
+					(reference "R2")
 					(unit 1)
 				)
 			)
@@ -3958,7 +3958,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "39dffa91-af0d-4ca9-a63f-55b2dfe93360")
-		(property "Reference" "#PWR047"
+		(property "Reference" "#PWR039"
 			(at 187.96 119.38 0)
 			(hide yes)
 			(show_name no)
@@ -4018,7 +4018,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR047")
+					(reference "#PWR039")
 					(unit 1)
 				)
 			)
@@ -4036,7 +4036,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "42111f93-8900-4c0c-8fd3-d6bec0d1cc0c")
-		(property "Reference" "#PWR023"
+		(property "Reference" "#PWR025"
 			(at 41.91 39.37 0)
 			(hide yes)
 			(show_name no)
@@ -4096,7 +4096,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR023")
+					(reference "#PWR025")
 					(unit 1)
 				)
 			)
@@ -4114,7 +4114,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "42bdfcb9-fa38-44a9-853f-d48b25a1e7bc")
-		(property "Reference" "#PWR059"
+		(property "Reference" "#PWR042"
 			(at 233.68 91.44 0)
 			(hide yes)
 			(show_name no)
@@ -4174,7 +4174,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR059")
+					(reference "#PWR042")
 					(unit 1)
 				)
 			)
@@ -4192,7 +4192,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4d9877cd-2a3b-4f67-a417-3a8d2146f0fc")
-		(property "Reference" "D4"
+		(property "Reference" "D1"
 			(at 38.4175 88.9 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4254,7 +4254,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "D4")
+					(reference "D1")
 					(unit 1)
 				)
 			)
@@ -4272,7 +4272,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4f821c36-e345-4b3c-916c-2f7f6e616abf")
-		(property "Reference" "#PWR056"
+		(property "Reference" "#PWR040"
 			(at 213.36 119.38 0)
 			(hide yes)
 			(show_name no)
@@ -4332,7 +4332,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR056")
+					(reference "#PWR040")
 					(unit 1)
 				)
 			)
@@ -4350,7 +4350,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "51cf57c3-01e3-4d89-ae3b-b777c14de87f")
-		(property "Reference" "#PWR051"
+		(property "Reference" "#PWR029"
 			(at 78.74 107.95 0)
 			(hide yes)
 			(show_name no)
@@ -4410,7 +4410,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR051")
+					(reference "#PWR029")
 					(unit 1)
 				)
 			)
@@ -4428,7 +4428,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6d4dd943-39ad-4b2b-8cd9-77e40ce68acc")
-		(property "Reference" "#PWR046"
+		(property "Reference" "#PWR022"
 			(at 20.32 104.14 0)
 			(hide yes)
 			(show_name no)
@@ -4488,7 +4488,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR046")
+					(reference "#PWR022")
 					(unit 1)
 				)
 			)
@@ -4506,7 +4506,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6ef5e22b-684c-40d3-ad48-28b36b75217f")
-		(property "Reference" "R2"
+		(property "Reference" "R6"
 			(at 267.97 38.0999 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4570,7 +4570,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "R2")
+					(reference "R6")
 					(unit 1)
 				)
 			)
@@ -4588,7 +4588,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "76cc41e0-4878-4f99-8943-41c51d758991")
-		(property "Reference" "R10"
+		(property "Reference" "R4"
 			(at 101.6 95.2499 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4652,7 +4652,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "R10")
+					(reference "R4")
 					(unit 1)
 				)
 			)
@@ -4670,7 +4670,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7a12e358-f1ac-4e45-9814-23b17c7b000c")
-		(property "Reference" "#PWR037"
+		(property "Reference" "#PWR045"
 			(at 265.43 49.53 0)
 			(hide yes)
 			(show_name no)
@@ -4730,7 +4730,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR037")
+					(reference "#PWR045")
 					(unit 1)
 				)
 			)
@@ -4748,7 +4748,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7a55f652-4958-4f34-b95d-22a242d495da")
-		(property "Reference" "#FLG05"
+		(property "Reference" "#FLG03"
 			(at 63.5 34.925 0)
 			(hide yes)
 			(show_name no)
@@ -4808,7 +4808,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#FLG05")
+					(reference "#FLG03")
 					(unit 1)
 				)
 			)
@@ -4826,7 +4826,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "807f5b1a-972f-49cb-a77a-1da472d5893b")
-		(property "Reference" "#PWR050"
+		(property "Reference" "#PWR036"
 			(at 148.59 127 0)
 			(hide yes)
 			(show_name no)
@@ -4886,7 +4886,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR050")
+					(reference "#PWR036")
 					(unit 1)
 				)
 			)
@@ -4903,7 +4903,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "808497ba-62fa-405e-9192-851689c2ff4e")
-		(property "Reference" "C15"
+		(property "Reference" "C10"
 			(at 189.23 104.14 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4967,7 +4967,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "C15")
+					(reference "C10")
 					(unit 1)
 				)
 			)
@@ -4985,7 +4985,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8455eb92-9069-472e-b8d2-0ed3600c79d7")
-		(property "Reference" "D1"
+		(property "Reference" "D2"
 			(at 269.24 29.5274 90)
 			(show_name no)
 			(do_not_autoplace no)
@@ -5060,7 +5060,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "D1")
+					(reference "D2")
 					(unit 1)
 				)
 			)
@@ -5078,7 +5078,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "88838d01-6370-47ea-9c9b-8c6b5babf92a")
-		(property "Reference" "#FLG04"
+		(property "Reference" "#FLG02"
 			(at 41.91 22.225 0)
 			(hide yes)
 			(show_name no)
@@ -5138,7 +5138,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#FLG04")
+					(reference "#FLG02")
 					(unit 1)
 				)
 			)
@@ -5156,7 +5156,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "92fe8fac-6bc0-49e4-8d11-1abec26824dc")
-		(property "Reference" "#PWR062"
+		(property "Reference" "#PWR033"
 			(at 127 40.64 0)
 			(hide yes)
 			(show_name no)
@@ -5216,7 +5216,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR062")
+					(reference "#PWR033")
 					(unit 1)
 				)
 			)
@@ -5234,7 +5234,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9ae0bbd9-659d-46ec-8f46-376e486a9743")
-		(property "Reference" "R8"
+		(property "Reference" "R5"
 			(at 138.43 111.7599 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -5298,7 +5298,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "R8")
+					(reference "R5")
 					(unit 1)
 				)
 			)
@@ -5476,7 +5476,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a794e9fa-d0ab-468f-a906-f816621a74c0")
-		(property "Reference" "#PWR057"
+		(property "Reference" "#PWR030"
 			(at 83.82 27.94 0)
 			(hide yes)
 			(show_name no)
@@ -5536,7 +5536,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR057")
+					(reference "#PWR030")
 					(unit 1)
 				)
 			)
@@ -5554,7 +5554,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "aeca7ec1-e3c0-4822-8b1c-7390ba6abb5e")
-		(property "Reference" "#PWR048"
+		(property "Reference" "#PWR032"
 			(at 121.92 127 0)
 			(hide yes)
 			(show_name no)
@@ -5614,7 +5614,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR048")
+					(reference "#PWR032")
 					(unit 1)
 				)
 			)
@@ -5632,7 +5632,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b142dbc9-2195-4747-906c-42118f02a58c")
-		(property "Reference" "#PWR038"
+		(property "Reference" "#PWR044"
 			(at 265.43 26.67 0)
 			(hide yes)
 			(show_name no)
@@ -5692,7 +5692,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR038")
+					(reference "#PWR044")
 					(unit 1)
 				)
 			)
@@ -5710,7 +5710,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b8f9ee2a-e1d1-4285-a569-e13745ff8a3e")
-		(property "Reference" "#PWR061"
+		(property "Reference" "#PWR037"
 			(at 161.29 88.9 0)
 			(hide yes)
 			(show_name no)
@@ -5770,7 +5770,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR061")
+					(reference "#PWR037")
 					(unit 1)
 				)
 			)
@@ -5788,7 +5788,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "bd7d220c-ee07-4791-b227-471b85b009b7")
-		(property "Reference" "#PWR049"
+		(property "Reference" "#PWR031"
 			(at 121.92 88.9 0)
 			(hide yes)
 			(show_name no)
@@ -5848,7 +5848,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR049")
+					(reference "#PWR031")
 					(unit 1)
 				)
 			)
@@ -5954,7 +5954,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c7dc22d0-684c-43a9-8266-850f4fd12036")
-		(property "Reference" "#PWR041"
+		(property "Reference" "#PWR028"
 			(at 63.5 27.94 0)
 			(hide yes)
 			(show_name no)
@@ -6014,7 +6014,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR041")
+					(reference "#PWR028")
 					(unit 1)
 				)
 			)
@@ -6032,7 +6032,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c8cbea60-7a0e-4144-af3d-6335bf132f95")
-		(property "Reference" "#PWR054"
+		(property "Reference" "#PWR027"
 			(at 46.99 114.3 0)
 			(hide yes)
 			(show_name no)
@@ -6092,7 +6092,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR054")
+					(reference "#PWR027")
 					(unit 1)
 				)
 			)
@@ -6110,7 +6110,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "cda2ef11-f94f-4170-993a-36ea83cd0e07")
-		(property "Reference" "#FLG06"
+		(property "Reference" "#FLG04"
 			(at 83.82 34.925 0)
 			(hide yes)
 			(show_name no)
@@ -6170,7 +6170,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#FLG06")
+					(reference "#FLG04")
 					(unit 1)
 				)
 			)
@@ -6188,7 +6188,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ce86efd4-61c9-438e-af01-254e392fd208")
-		(property "Reference" "R7"
+		(property "Reference" "R3"
 			(at 91.44 95.2499 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6252,7 +6252,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "R7")
+					(reference "R3")
 					(unit 1)
 				)
 			)
@@ -6270,7 +6270,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d46af8e9-67d2-4235-aa87-8d1a60fa9926")
-		(property "Reference" "#PWR055"
+		(property "Reference" "#PWR041"
 			(at 228.6 119.38 0)
 			(hide yes)
 			(show_name no)
@@ -6330,7 +6330,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR055")
+					(reference "#PWR041")
 					(unit 1)
 				)
 			)
@@ -6348,7 +6348,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e3c490fd-42ab-4412-b0d3-604f9aeb3ba5")
-		(property "Reference" "#PWR058"
+		(property "Reference" "#PWR043"
 			(at 260.35 91.44 0)
 			(hide yes)
 			(show_name no)
@@ -6408,7 +6408,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR058")
+					(reference "#PWR043")
 					(unit 1)
 				)
 			)
@@ -6426,7 +6426,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e95cf632-5f84-49a9-a553-cdcacc0c3d88")
-		(property "Reference" "#PWR063"
+		(property "Reference" "#PWR034"
 			(at 130.81 27.94 0)
 			(hide yes)
 			(show_name no)
@@ -6486,7 +6486,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR063")
+					(reference "#PWR034")
 					(unit 1)
 				)
 			)
@@ -6504,7 +6504,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e9aae3e3-04a7-40db-a956-094731731bb6")
-		(property "Reference" "#PWR036"
+		(property "Reference" "#PWR024"
 			(at 31.75 27.94 0)
 			(hide yes)
 			(show_name no)
@@ -6564,7 +6564,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR036")
+					(reference "#PWR024")
 					(unit 1)
 				)
 			)
@@ -6582,7 +6582,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ea8ccfef-068b-445b-9886-7ebd4ee5f077")
-		(property "Reference" "#PWR052"
+		(property "Reference" "#PWR035"
 			(at 135.89 127 0)
 			(hide yes)
 			(show_name no)
@@ -6642,7 +6642,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "#PWR052")
+					(reference "#PWR035")
 					(unit 1)
 				)
 			)
@@ -6659,7 +6659,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "f649a08c-647d-4e6b-a1b3-70a5c808b507")
-		(property "Reference" "C16"
+		(property "Reference" "C11"
 			(at 229.87 104.14 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6723,7 +6723,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "C16")
+					(reference "C11")
 					(unit 1)
 				)
 			)
@@ -6740,7 +6740,7 @@
 		(in_pos_files yes)
 		(dnp no)
 		(uuid "fd2deb70-1b70-4c5c-96f0-600de5ea7c7a")
-		(property "Reference" "C11"
+		(property "Reference" "C9"
 			(at 149.86 105.41 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6804,7 +6804,7 @@
 		(instances
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
-					(reference "C11")
+					(reference "C9")
 					(unit 1)
 				)
 			)


### PR DESCRIPTION
- Standardized the schematic component designations by re-sorting and annotating symbols based on their X position across the sheets for a cleaner, left-to-right design flow.
- Purged broken, absolute external user file paths within the local fp-lib-table that were causing environment errors on initialization.