### PR TITLE
fix(usb): correct D+/D- routing between J3 and U5

### DIFF
--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -2619,22 +2619,22 @@
 		(uuid "30ce3852-67b5-499d-bb1a-d03b7b3ed2a1")
 	)
 	(junction
+		(at 204.47 134.62)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ef8f5390-5bab-4421-a2c4-421a0cf5a7ef")
+	)
+	(junction
 		(at 110.49 111.76)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "3400ef6b-ed27-498b-b1cb-69fad5c36855")
+		(uuid "f0270542-727b-4c88-8a60-841ec7f1c276")
 	)
 	(junction
 		(at 110.49 106.68)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "6bf1c60a-15e8-44c7-8d7f-770e0fd62223")
-	)
-	(junction
-		(at 204.47 134.62)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "ef8f5390-5bab-4421-a2c4-421a0cf5a7ef")
+		(uuid "f2404799-2756-48d1-9018-b9c074f1253e")
 	)
 	(no_connect
 		(at 222.25 101.6)
@@ -2690,13 +2690,13 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 106.68) (xy 118.11 106.68)
+			(xy 123.19 111.76) (xy 110.49 111.76)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "17364e56-690b-4ae0-95be-bfc9702170a0")
+		(uuid "1a6dd8aa-b99e-4f2f-a3a5-f6c8a632d03b")
 	)
 	(wire
 		(pts
@@ -2720,13 +2720,13 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 111.76) (xy 118.11 111.76)
+			(xy 110.49 106.68) (xy 110.49 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "27615f0b-8865-4439-8071-f065831d2cfc")
+		(uuid "28eccbeb-5618-4401-ba1d-f704a77b0b63")
 	)
 	(wire
 		(pts
@@ -2761,6 +2761,16 @@
 	)
 	(wire
 		(pts
+			(xy 110.49 111.76) (xy 110.49 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "53df4aff-11b5-4973-b83a-85b0303b0f11")
+	)
+	(wire
+		(pts
 			(xy 213.36 20.32) (xy 213.36 22.86)
 		)
 		(stroke
@@ -2771,7 +2781,7 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 111.76) (xy 110.49 113.03)
+			(xy 110.49 110.49) (xy 110.49 111.76)
 		)
 		(stroke
 			(width 0)
@@ -2878,6 +2888,16 @@
 			(type default)
 		)
 		(uuid "782c9c2f-e5ed-442d-981a-a084456c4223")
+	)
+	(wire
+		(pts
+			(xy 123.19 106.68) (xy 110.49 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a82c14c-2c28-4e54-b1fc-65a3ed961154")
 	)
 	(wire
 		(pts
@@ -3073,16 +3093,6 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 106.68) (xy 110.49 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "edfadf42-e0fc-4844-8a26-2f4c84f04824")
-	)
-	(wire
-		(pts
 			(xy 110.49 92.71) (xy 111.76 92.71)
 		)
 		(stroke
@@ -3100,16 +3110,6 @@
 			(type default)
 		)
 		(uuid "f181be80-3e2c-42c2-94b7-53e8a81537d2")
-	)
-	(wire
-		(pts
-			(xy 110.49 110.49) (xy 110.49 111.76)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f953afcf-be9b-4ae7-a747-e49c8fb9a403")
 	)
 	(polyline
 		(pts
@@ -3132,6 +3132,16 @@
 		)
 		(uuid "fba18a9c-d0de-4de3-817a-196796f86279")
 	)
+	(label "USBD+"
+		(at 123.19 111.76 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "0290af91-878f-4bc0-82d6-7708abf6d87b")
+	)
 	(label "CC2"
 		(at 274.32 16.51 0)
 		(effects
@@ -3141,16 +3151,6 @@
 			(justify left bottom)
 		)
 		(uuid "258bf8e1-2933-433e-a0cf-64b0c3ccfce9")
-	)
-	(label "USBD+"
-		(at 118.11 106.68 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "26a746a3-750b-4cc6-9767-bd8c7172c191")
 	)
 	(label "CC1"
 		(at 118.11 97.79 180)
@@ -3192,16 +3192,6 @@
 		)
 		(uuid "a641cc17-7d4f-4b0b-b4b8-10aaea87dc55")
 	)
-	(label "USBD-"
-		(at 118.11 111.76 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "b7a1861c-e729-499f-a464-9da1ae688101")
-	)
 	(label "CC2"
 		(at 118.11 100.33 180)
 		(effects
@@ -3211,6 +3201,16 @@
 			(justify right bottom)
 		)
 		(uuid "c52d0131-fcfd-48cb-b663-4a5d112b4d1e")
+	)
+	(label "USBD-"
+		(at 123.19 106.68 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "d31a13e0-a3f3-4125-9776-0eccbf2fbbd5")
 	)
 	(label "TXLED"
 		(at 232.41 46.99 0)


### PR DESCRIPTION
USB data lines were swapped at the Type-C receptacle. J3 D+ now routes to U5 USBD+ and J3 D- to U5 USBD-.