### PR TITLE
Fix/p0 critical fixes

### DIFF
--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -863,7 +863,7 @@
         "uuid": "01550cd7-b424-469c-925b-c370f3609cd4"
       }
     ],
-    "used_designators": "C13-14,#PWR59-60,Y1,R11",
+    "used_designators": "C13-14,#PWR59-62,Y1,R11-12",
     "variants": []
   },
   "sheets": [

--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -863,7 +863,7 @@
         "uuid": "01550cd7-b424-469c-925b-c370f3609cd4"
       }
     ],
-    "used_designators": "R11",
+    "used_designators": "C13-14,#PWR59-60,Y1,R11",
     "variants": []
   },
   "sheets": [

--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -863,7 +863,7 @@
         "uuid": "01550cd7-b424-469c-925b-c370f3609cd4"
       }
     ],
-    "used_designators": "C13-14,#PWR59-62,Y1,R11-12",
+    "used_designators": "J4,C13-14,#PWR59-64,Y1,R11-12",
     "variants": []
   },
   "sheets": [

--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -863,7 +863,7 @@
         "uuid": "01550cd7-b424-469c-925b-c370f3609cd4"
       }
     ],
-    "used_designators": "",
+    "used_designators": "R11",
     "variants": []
   },
   "sheets": [

--- a/HW.kicad_pro
+++ b/HW.kicad_pro
@@ -863,7 +863,7 @@
         "uuid": "01550cd7-b424-469c-925b-c370f3609cd4"
       }
     ],
-    "used_designators": "J4,C13-14,#PWR59-64,Y1,R11-12",
+    "used_designators": "J4,C13-14,#PWR59-65,Y1,R11-12",
     "variants": []
   },
   "sheets": [

--- a/USB_UART.kicad_sch
+++ b/USB_UART.kicad_sch
@@ -873,6 +873,162 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "Device:C_Small"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.254 1.778 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C_Small"
+				(at 0.254 -2.032 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor, small symbol"
+				(at 0 -10.16 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "capacitor cap"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_Small_0_1"
+				(polyline
+					(pts
+						(xy -1.524 0.508) (xy 1.524 0.508)
+					)
+					(stroke
+						(width 0.3048)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.524 -0.508) (xy 1.524 -0.508)
+					)
+					(stroke
+						(width 0.3048)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_Small_1_1"
+				(pin passive line
+					(at 0 2.54 270)
+					(length 2.032)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -2.54 90)
+					(length 2.032)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Device:FerriteBead_Small"
 			(pin_numbers
 				(hide yes)
@@ -1949,6 +2105,182 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "PCM_SparkFun-Clock:Crystal"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "Y"
+				(at 0 2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Crystal"
+				(at 0 -2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "PCM_SparkFun-Clock:Crystal-SMD-5x3.2mm"
+				(at 0 -7.62 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -5.08 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Crystal"
+				(at 0 -12.7 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "PROD_ID" "XTAL-"
+				(at 0 -10.16 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "SparkFun quartz ceramic resonator oscillator"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Crystal*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Crystal_0_1"
+				(polyline
+					(pts
+						(xy -1.27 -0.762) (xy -1.27 0.762)
+					)
+					(stroke
+						(width 0.381)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -0.762 -1.524)
+					(end 0.762 1.524)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -0.762) (xy 1.27 0.762)
+					)
+					(stroke
+						(width 0.381)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Crystal_1_1"
+				(pin passive line
+					(at -2.54 0 0)
+					(length 1.27)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 0 180)
+					(length 1.27)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "power:+3.3V"
 			(power global)
 			(pin_numbers
@@ -2613,10 +2945,22 @@
 		(uuid "b1257d3e-b11a-40fe-a824-c685665f3815")
 	)
 	(junction
+		(at 147.32 127)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2f32f982-50b4-4725-bfd4-51a7c075c8a6")
+	)
+	(junction
 		(at 196.85 139.7)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "30ce3852-67b5-499d-bb1a-d03b7b3ed2a1")
+	)
+	(junction
+		(at 163.83 127)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "98bee853-7857-4d5e-907e-be58538c2814")
 	)
 	(junction
 		(at 204.47 134.62)
@@ -2649,10 +2993,6 @@
 		(uuid "8fae41a0-0e47-41d7-9422-25263397e7e7")
 	)
 	(no_connect
-		(at 181.61 119.38)
-		(uuid "9be4298f-6fb6-4efd-b86e-51ac092eb9f7")
-	)
-	(no_connect
 		(at 222.25 106.68)
 		(uuid "a0b023d3-ef01-4828-806e-30f6f31a5b41")
 	)
@@ -2669,10 +3009,6 @@
 		(uuid "bd7f7341-8760-47fb-ad7d-362895cbef2b")
 	)
 	(no_connect
-		(at 181.61 114.3)
-		(uuid "ce1c43fe-49fe-4733-9524-b8a94dbf15fb")
-	)
-	(no_connect
 		(at 110.49 120.65)
 		(uuid "db76a7a5-23d9-4668-80a8-72bff9143d8b")
 	)
@@ -2687,6 +3023,36 @@
 	(no_connect
 		(at 222.25 121.92)
 		(uuid "f512327e-0d35-4b5c-8c1a-fafb6bc3a42c")
+	)
+	(wire
+		(pts
+			(xy 181.61 119.38) (xy 163.83 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09fa8bf2-a245-4bd1-8af4-0d7ef9964a2e")
+	)
+	(wire
+		(pts
+			(xy 163.83 135.89) (xy 163.83 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "16516251-7e0c-4b63-b309-838d7959c630")
+	)
+	(wire
+		(pts
+			(xy 163.83 127) (xy 163.83 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "19b2a542-60c3-480c-8ca0-62e861b35809")
 	)
 	(wire
 		(pts
@@ -2737,6 +3103,26 @@
 			(type default)
 		)
 		(uuid "2e5ea586-c4f2-44c7-bbe3-9f38a0a4ff3a")
+	)
+	(wire
+		(pts
+			(xy 158.75 127) (xy 163.83 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "30332ffa-d6a4-43e4-a8ac-5de5ac7f9e11")
+	)
+	(wire
+		(pts
+			(xy 147.32 130.81) (xy 147.32 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "328b6fae-7c2b-430b-b67e-8270b1513614")
 	)
 	(wire
 		(pts
@@ -2943,6 +3329,16 @@
 	)
 	(wire
 		(pts
+			(xy 147.32 114.3) (xy 147.32 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9022db24-02ca-4e45-8628-de088af8db8f")
+	)
+	(wire
+		(pts
 			(xy 195.58 139.7) (xy 196.85 139.7)
 		)
 		(stroke
@@ -2973,6 +3369,16 @@
 	)
 	(wire
 		(pts
+			(xy 147.32 127) (xy 153.67 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c978791-5356-42e8-8ef5-d2c14c0af8d1")
+	)
+	(wire
+		(pts
 			(xy 222.25 119.38) (xy 228.6 119.38)
 		)
 		(stroke
@@ -3000,6 +3406,16 @@
 			(type default)
 		)
 		(uuid "af8cd4bb-1848-4d31-a7a4-86b7c4d4882d")
+	)
+	(wire
+		(pts
+			(xy 147.32 135.89) (xy 147.32 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b1d57c05-e46b-4315-abd1-7b75e0c639d9")
 	)
 	(wire
 		(pts
@@ -3043,6 +3459,16 @@
 	)
 	(wire
 		(pts
+			(xy 163.83 119.38) (xy 163.83 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd8991d1-3d0b-4e2f-988c-6d86eb50b3ee")
+	)
+	(wire
+		(pts
 			(xy 196.85 139.7) (xy 196.85 142.24)
 		)
 		(stroke
@@ -3080,6 +3506,16 @@
 			(type default)
 		)
 		(uuid "df177d23-d424-4921-8593-822b1d505dd0")
+	)
+	(wire
+		(pts
+			(xy 181.61 114.3) (xy 147.32 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e3ae77c2-3e97-4d44-b029-716e3006b69d")
 	)
 	(wire
 		(pts
@@ -3680,6 +4116,87 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "U5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Small")
+		(at 147.32 133.35 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "1a0e7dbd-0613-4ff2-8be5-63dfec0fe37d")
+		(property "Reference" "C13"
+			(at 147.32 131.826 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "27pF"
+			(at 147.574 135.128 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "PCM_SparkFun-Capacitor:C_0603_1608Metric"
+			(at 147.32 133.35 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 147.32 133.35 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Unpolarized capacitor, small symbol"
+			(at 147.32 143.51 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "e6f323b9-b0e0-4023-8144-15e3a93667b1")
+		)
+		(pin "1"
+			(uuid "5c8e8476-3e06-4f07-b7c2-03478e36d0c6")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "C13")
 					(unit 1)
 				)
 			)
@@ -4326,6 +4843,83 @@
 	)
 	(symbol
 		(lib_id "power:GND")
+		(at 147.32 137.16 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "6c1b75ab-b74a-4ea4-a692-472df80d18d7")
+		(property "Reference" "#PWR059"
+			(at 147.32 143.51 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 147.32 140.97 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 147.32 137.16 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 147.32 137.16 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 147.32 137.16 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "2b9899c5-6df4-4d50-8230-376b0caf32ff")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR059")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
 		(at 143.51 100.33 0)
 		(unit 1)
 		(body_style 1)
@@ -4397,6 +4991,83 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "#PWR049")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 163.83 137.16 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "7b104f03-997c-4221-9fed-a61a73cf4d1a")
+		(property "Reference" "#PWR060"
+			(at 163.83 143.51 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 163.83 140.97 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 163.83 137.16 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 137.16 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 163.83 137.16 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "76f2ec31-0dd1-4290-aa51-188c19160dff")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "#PWR060")
 					(unit 1)
 				)
 			)
@@ -5174,6 +5845,177 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
 					(reference "#PWR054")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "PCM_SparkFun-Clock:Crystal")
+		(at 156.21 127 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "e6af6f01-843a-41e1-b32e-355b22a5a2c3")
+		(property "Reference" "Y1"
+			(at 156.21 124.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "12MHz"
+			(at 156.464 129.794 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Crystal:Crystal_SMD_0603-2Pin_6.0x3.5mm_HandSoldering"
+			(at 156.21 134.62 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 156.21 132.08 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Crystal"
+			(at 156.21 139.7 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "PROD_ID" "XTAL-"
+			(at 156.21 137.16 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "50cec485-209a-414f-b7e0-700813ec5a11")
+		)
+		(pin "1"
+			(uuid "2e37742a-2066-489c-a00f-e30cdab5a6e9")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "Y1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Small")
+		(at 163.83 133.35 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "ed50219a-5a9f-4fdb-a5e7-1a61eb57afb8")
+		(property "Reference" "C14"
+			(at 163.83 131.826 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "27pF"
+			(at 163.83 135.128 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "PCM_SparkFun-Capacitor:C_0603_1608Metric"
+			(at 163.83 133.35 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 133.35 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Unpolarized capacitor, small symbol"
+			(at 163.83 143.51 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "d4899628-0d65-4347-92c1-fb07fb6574ec")
+		)
+		(pin "1"
+			(uuid "323eb188-adeb-46eb-89b8-4f6d2f8134a5")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/b4895c98-2d65-46cb-a7d2-9672cea4def2"
+					(reference "C14")
 					(unit 1)
 				)
 			)

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -1970,16 +1970,6 @@
 	)
 	(wire
 		(pts
-			(xy 59.69 34.29) (xy 59.69 38.1)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "34499f48-6927-4899-850f-d9d48182946a")
-	)
-	(wire
-		(pts
 			(xy 267.97 45.72) (xy 267.97 46.99)
 		)
 		(stroke
@@ -2007,6 +1997,26 @@
 			(type default)
 		)
 		(uuid "4b070afd-16ee-4aff-a386-008f8fe46491")
+	)
+	(wire
+		(pts
+			(xy 107.95 33.02) (xy 107.95 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e6401d3-ccf5-4921-923f-7dc3004bf514")
+	)
+	(wire
+		(pts
+			(xy 59.69 34.29) (xy 59.69 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "558cac5e-913b-4cf8-91f5-f8ec4c73bf0b")
 	)
 	(wire
 		(pts
@@ -2092,6 +2102,16 @@
 	)
 	(wire
 		(pts
+			(xy 104.14 33.02) (xy 107.95 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8477956c-37f1-435f-a800-b8f1d7a48937")
+	)
+	(wire
+		(pts
 			(xy 157.48 81.28) (xy 157.48 82.55)
 		)
 		(stroke
@@ -2160,6 +2180,16 @@
 			(color 72 72 72 1)
 		)
 		(uuid "ac6ff31a-14e7-4d43-835c-e226a83a6e4c")
+	)
+	(wire
+		(pts
+			(xy 93.98 33.02) (xy 99.06 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b1c747c0-ccea-4f58-b052-e8960a2d63bd")
 	)
 	(wire
 		(pts
@@ -2276,13 +2306,13 @@
 	)
 	(wire
 		(pts
-			(xy 69.85 34.29) (xy 69.85 38.1)
+			(xy 69.85 34.29) (xy 69.85 40.64)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f4d9c94f-1aa8-4822-be41-adba1700a9a7")
+		(uuid "f662f548-78f3-48c6-95b7-33eb107e4470")
 	)
 	(wire
 		(pts
@@ -2293,6 +2323,16 @@
 			(type default)
 		)
 		(uuid "f6d05204-004b-4e90-86a7-eac1f3a8d5f1")
+	)
+	(wire
+		(pts
+			(xy 93.98 35.56) (xy 93.98 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fc1f2b8a-3909-4a3d-bf27-a019ea5ab3b8")
 	)
 	(label "BOOT0"
 		(at 134.62 95.25 0)
@@ -2966,6 +3006,164 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R_Small")
+		(at 101.6 33.02 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "2cc70b2b-d347-4428-b09a-4cd17bc7b08c")
+		(property "Reference" "R12"
+			(at 103.124 31.496 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "0 Ohm"
+			(at 105.156 34.798 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 101.6 33.02 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 101.6 33.02 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 101.6 33.02 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "a2039021-f537-4733-97bd-73b75c80fdcb")
+		)
+		(pin "1"
+			(uuid "873d4aa0-82eb-433a-9c35-bd2440e34d6d")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
+					(reference "R12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GNDA")
+		(at 107.95 35.56 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "2e27bb09-6f2c-4b62-92ef-3902b5afd30f")
+		(property "Reference" "#PWR062"
+			(at 107.95 41.91 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GNDA"
+			(at 107.95 39.37 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 107.95 35.56 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 107.95 35.56 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
+			(at 107.95 35.56 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "97547e8d-273c-4077-b63e-2d10ae384b26")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
+					(reference "#PWR062")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:+3.3V")
 		(at 21.59 27.94 0)
 		(unit 1)
@@ -3431,7 +3629,7 @@
 	)
 	(symbol
 		(lib_id "power:GNDA")
-		(at 69.85 38.1 0)
+		(at 69.85 40.64 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -3439,10 +3637,9 @@
 		(on_board yes)
 		(in_pos_files yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "72cd3963-a148-4f20-bbd4-608721091f90")
 		(property "Reference" "#PWR014"
-			(at 69.85 44.45 0)
+			(at 69.85 46.99 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3453,7 +3650,7 @@
 			)
 		)
 		(property "Value" "GNDA"
-			(at 69.85 43.18 0)
+			(at 69.85 44.45 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -3463,7 +3660,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 69.85 38.1 0)
+			(at 69.85 40.64 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3474,7 +3671,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 69.85 38.1 0)
+			(at 69.85 40.64 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3485,7 +3682,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
-			(at 69.85 38.1 0)
+			(at 69.85 40.64 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3662,6 +3859,83 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
 					(reference "J1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 93.98 35.56 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "993b8fc5-00a0-4f65-adcf-a0c2351197a3")
+		(property "Reference" "#PWR061"
+			(at 93.98 41.91 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 93.98 39.37 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 93.98 35.56 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 93.98 35.56 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 93.98 35.56 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "b1af4ab3-bf62-4f2c-9cdd-5072f34f9f03")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
+					(reference "#PWR061")
 					(unit 1)
 				)
 			)
@@ -3906,7 +4180,7 @@
 	)
 	(symbol
 		(lib_id "power:GNDA")
-		(at 59.69 38.1 0)
+		(at 59.69 40.64 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -3914,10 +4188,9 @@
 		(on_board yes)
 		(in_pos_files yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "c7a0af5b-a88e-4b44-9332-629f45879089")
 		(property "Reference" "#PWR012"
-			(at 59.69 44.45 0)
+			(at 59.69 46.99 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3928,7 +4201,7 @@
 			)
 		)
 		(property "Value" "GNDA"
-			(at 59.69 43.18 0)
+			(at 59.69 44.45 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -3938,7 +4211,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 59.69 38.1 0)
+			(at 59.69 40.64 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3949,7 +4222,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 59.69 38.1 0)
+			(at 59.69 40.64 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3960,7 +4233,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GNDA\" , analog ground"
-			(at 59.69 38.1 0)
+			(at 59.69 40.64 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -227,6 +227,269 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "Connector:Conn_01x04_Pin"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at 0 5.08 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x04_Pin"
+				(at 0 -7.62 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x04, script generated"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_locked" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Conn_01x04_Pin_1_1"
+				(rectangle
+					(start 0.8636 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 0.8636 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 0.8636 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 0.8636 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 2.54) (xy 0.8636 2.54)
+					)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy 0.8636 0)
+					)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -2.54) (xy 0.8636 -2.54)
+					)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -5.08) (xy 0.8636 -5.08)
+					)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at 5.08 2.54 180)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 -2.54 180)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 -5.08 180)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Device:C_Small"
 			(pin_numbers
 				(hide yes)
@@ -1814,10 +2077,6 @@
 		(uuid "011659b3-2adb-4d75-ace4-7e484797a9b7")
 	)
 	(no_connect
-		(at 167.64 118.11)
-		(uuid "0e29bd33-808c-45fe-8182-d20c06e44a24")
-	)
-	(no_connect
 		(at 142.24 107.95)
 		(uuid "5aa4cea5-ff57-4c19-860d-54e737ff2ff0")
 	)
@@ -1840,10 +2099,6 @@
 	(no_connect
 		(at 167.64 90.17)
 		(uuid "ef30e4bd-02f3-404a-a266-8220a14d9cd6")
-	)
-	(no_connect
-		(at 167.64 115.57)
-		(uuid "ef394530-e8f1-488c-8f0a-1b90d279f557")
 	)
 	(wire
 		(pts
@@ -1950,6 +2205,16 @@
 	)
 	(wire
 		(pts
+			(xy 170.18 115.57) (xy 167.64 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e81989e-7519-4ef6-803a-c23cc4291648")
+	)
+	(wire
+		(pts
 			(xy 34.29 30.48) (xy 34.29 27.94)
 		)
 		(stroke
@@ -1967,6 +2232,16 @@
 			(type default)
 		)
 		(uuid "33007c30-28bc-4b06-8bf0-3d5faa633ae0")
+	)
+	(wire
+		(pts
+			(xy 255.27 140.97) (xy 261.62 140.97)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35f352f2-5245-4efe-872b-80f72e62d732")
 	)
 	(wire
 		(pts
@@ -2007,6 +2282,16 @@
 			(type default)
 		)
 		(uuid "4e6401d3-ccf5-4921-923f-7dc3004bf514")
+	)
+	(wire
+		(pts
+			(xy 255.27 133.35) (xy 261.62 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50e92128-12f9-4a9f-a1f0-9bc82b6c45b6")
 	)
 	(wire
 		(pts
@@ -2081,6 +2366,16 @@
 	)
 	(wire
 		(pts
+			(xy 182.88 116.84) (xy 170.18 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "761aa7e3-5b9d-46ea-bd0e-dd8275145e88")
+	)
+	(wire
+		(pts
 			(xy 59.69 26.67) (xy 59.69 29.21)
 		)
 		(stroke
@@ -2102,6 +2397,16 @@
 	)
 	(wire
 		(pts
+			(xy 170.18 119.38) (xy 182.88 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8239d504-ac69-4aff-a43a-eca072980d19")
+	)
+	(wire
+		(pts
 			(xy 104.14 33.02) (xy 107.95 33.02)
 		)
 		(stroke
@@ -2119,6 +2424,26 @@
 			(type default)
 		)
 		(uuid "85a09ce2-868e-4f1b-ab26-337260be9f96")
+	)
+	(wire
+		(pts
+			(xy 170.18 116.84) (xy 170.18 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86639506-ab49-4e0d-b703-cf276c9a0e77")
+	)
+	(wire
+		(pts
+			(xy 255.27 135.89) (xy 271.78 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9180a669-f7ac-46ec-b198-d161b8459263")
 	)
 	(wire
 		(pts
@@ -2170,6 +2495,16 @@
 		)
 		(uuid "a5a72c6d-4b97-4233-9ec7-7795ef66e04c")
 	)
+	(wire
+		(pts
+			(xy 255.27 138.43) (xy 271.78 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a9d94d40-57bc-40c1-82eb-e12c22084632")
+	)
 	(polyline
 		(pts
 			(xy 12.7 46.99) (xy 39.37 46.99)
@@ -2203,6 +2538,16 @@
 	)
 	(wire
 		(pts
+			(xy 170.18 118.11) (xy 167.64 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b97b42be-7ef9-4b67-9710-83e069fdaa31")
+	)
+	(wire
+		(pts
 			(xy 134.62 95.25) (xy 142.24 95.25)
 		)
 		(stroke
@@ -2213,6 +2558,26 @@
 	)
 	(wire
 		(pts
+			(xy 170.18 119.38) (xy 170.18 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf70b75a-8ec7-4ae2-8f1f-611dbf59734e")
+	)
+	(wire
+		(pts
+			(xy 261.62 140.97) (xy 261.62 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c36347b4-2f4b-43d9-a51d-aab8980318e7")
+	)
+	(wire
+		(pts
 			(xy 167.64 113.03) (xy 171.45 113.03)
 		)
 		(stroke
@@ -2220,6 +2585,16 @@
 			(type default)
 		)
 		(uuid "c3dde6da-8a2c-46b8-b6a4-c34602468837")
+	)
+	(wire
+		(pts
+			(xy 261.62 133.35) (xy 261.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d0bc82b5-cbb5-4c92-9efd-a328e9cad8d9")
 	)
 	(polyline
 		(pts
@@ -2354,6 +2729,16 @@
 		)
 		(uuid "2620004f-9060-47d5-8115-e0331145ad42")
 	)
+	(label "SWDIO"
+		(at 182.88 116.84 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "3af4ce74-b633-4a7a-a7b3-517007f1ab6c")
+	)
 	(label "RESET"
 		(at 135.89 90.17 0)
 		(effects
@@ -2364,6 +2749,26 @@
 		)
 		(uuid "4cc44811-c4f0-4427-a87b-006095a67b08")
 	)
+	(label "SWCLK"
+		(at 182.88 119.38 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "79f3333f-df37-4e88-9170-b913a44ba012")
+	)
+	(label "SWCLK"
+		(at 271.78 135.89 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "87439dde-56ec-4342-958a-aacd9e7354c2")
+	)
 	(label "BOOT0"
 		(at 241.3 38.1 180)
 		(effects
@@ -2373,6 +2778,16 @@
 			(justify right bottom)
 		)
 		(uuid "bb1c31a7-5734-47b2-9091-2d3be86dc289")
+	)
+	(label "SWDIO"
+		(at 271.78 138.43 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "ca5f5b99-eaff-4bcb-a3bd-6352fc76b385")
 	)
 	(hierarchical_label "USART1_TX"
 		(shape output)
@@ -2523,6 +2938,84 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
 					(reference "#PWR020")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 261.62 146.05 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "191e1c4f-dd8d-49ea-99ab-87d4b961ca05")
+		(property "Reference" "#PWR064"
+			(at 261.62 152.4 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 261.62 151.13 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 261.62 146.05 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 261.62 146.05 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 261.62 146.05 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "998f54ae-c202-4c5c-b188-376dfa4fadfa")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
+					(reference "#PWR064")
 					(unit 1)
 				)
 			)
@@ -3865,6 +4358,84 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+3.3V")
+		(at 261.62 129.54 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "981f09d2-4887-4255-beee-4222c72c530d")
+		(property "Reference" "#PWR063"
+			(at 261.62 133.35 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 261.62 124.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 261.62 129.54 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 261.62 129.54 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 261.62 129.54 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e18e7b22-961c-45e5-ab6e-c7e779ec7a3b")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
+					(reference "#PWR063")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
 		(at 93.98 35.56 0)
 		(unit 1)
@@ -4407,6 +4978,91 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
 					(reference "#PWR010")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:Conn_01x04_Pin")
+		(at 250.19 135.89 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "dd5f3a65-b1eb-4864-940f-bbacb97163b5")
+		(property "Reference" "J4"
+			(at 250.952 131.572 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Conn_01x04_Pin"
+			(at 250.19 143.764 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical"
+			(at 250.19 135.89 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 250.19 135.89 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x04, script generated"
+			(at 250.19 135.89 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "4cc67f92-f58e-42e0-83f7-17f91816894a")
+		)
+		(pin "4"
+			(uuid "23a42418-5120-4e31-81d3-b301dc92658b")
+		)
+		(pin "3"
+			(uuid "8eca93e9-9db8-48ab-8204-be116bb6465d")
+		)
+		(pin "2"
+			(uuid "8a87bf8b-03ee-4b25-916b-659f29e137d3")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/edb1e4c3-83a3-4443-aa4b-0e758d3bea47"
+					(reference "J4")
 					(unit 1)
 				)
 			)

--- a/mcu.kicad_sch
+++ b/mcu.kicad_sch
@@ -3616,7 +3616,7 @@
 				)
 			)
 		)
-		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Horizontal"
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical"
 			(at 213.36 38.1 0)
 			(hide yes)
 			(show_name no)

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -2542,10 +2542,6 @@
 		(uuid "e05453c0-9ef5-4e5a-a222-330e54793bb4")
 	)
 	(no_connect
-		(at 133.35 102.87)
-		(uuid "a19a9292-2794-44aa-8e59-05a993e8303e")
-	)
-	(no_connect
 		(at 119.38 115.57)
 		(uuid "e8411df5-e51c-4dbd-b602-0af9bcc287c1")
 	)
@@ -2855,6 +2851,16 @@
 	)
 	(wire
 		(pts
+			(xy 143.51 102.87) (xy 143.51 120.65)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "831e986a-ac59-4e0d-82c6-47262cb3f553")
+	)
+	(wire
+		(pts
 			(xy 121.92 115.57) (xy 121.92 120.65)
 		)
 		(stroke
@@ -3005,7 +3011,7 @@
 	)
 	(wire
 		(pts
-			(xy 132.08 102.87) (xy 133.35 102.87)
+			(xy 132.08 102.87) (xy 143.51 102.87)
 		)
 		(stroke
 			(width 0)
@@ -4733,6 +4739,84 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
 					(reference "R4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 143.51 120.65 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "791b612f-61d5-4ed4-89c5-5385701fb039")
+		(property "Reference" "#PWR065"
+			(at 143.51 127 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 143.51 125.73 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 143.51 120.65 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 143.51 120.65 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 143.51 120.65 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8ee434ec-cf42-4aba-8c68-fbc65cb99a8c")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "#PWR065")
 					(unit 1)
 				)
 			)

--- a/power_tree.kicad_sch
+++ b/power_tree.kicad_sch
@@ -2470,6 +2470,18 @@
 		(uuid "7f2f9baf-df92-4180-83ee-a4435784939a")
 	)
 	(junction
+		(at 91.44 83.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "01ac5905-9705-46cf-9ee3-55f63ab67796")
+	)
+	(junction
+		(at 121.92 83.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1e0a9bf0-980f-47c8-9ed2-e0465b8bf127")
+	)
+	(junction
 		(at 187.96 99.06)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2488,12 +2500,6 @@
 		(uuid "60ea839e-0f2b-451f-a7a8-0907e0a67b47")
 	)
 	(junction
-		(at 121.92 88.9)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "6e0493bf-dd07-40fb-adc5-66d64684ba35")
-	)
-	(junction
 		(at 228.6 99.06)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2506,13 +2512,13 @@
 		(uuid "b5ada9b7-3f13-405a-8471-17b0d55b8137")
 	)
 	(junction
-		(at 88.9 88.9)
+		(at 82.55 83.82)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "bdc53318-c60c-4ee7-b151-0a4f8123bfe6")
 	)
 	(junction
-		(at 99.06 88.9)
+		(at 99.06 83.82)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d09c728e-1757-4497-a032-aea94fb996ed")
@@ -2534,12 +2540,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "e05453c0-9ef5-4e5a-a222-330e54793bb4")
-	)
-	(junction
-		(at 109.22 102.87)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "f9160819-9adf-4435-8a76-64ad3d4a5cd2")
 	)
 	(no_connect
 		(at 133.35 102.87)
@@ -2578,16 +2578,6 @@
 			(type default)
 		)
 		(uuid "063faf23-b925-457e-9b2f-6e29acc4d94f")
-	)
-	(wire
-		(pts
-			(xy 99.06 102.87) (xy 109.22 102.87)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0e6bb0f9-9457-4bac-9323-af8352a3dcd0")
 	)
 	(wire
 		(pts
@@ -2682,6 +2672,16 @@
 	)
 	(wire
 		(pts
+			(xy 99.06 97.79) (xy 111.76 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "317d882e-9a4e-4b8a-81b8-5b98f097b3d6")
+	)
+	(wire
+		(pts
 			(xy 260.35 99.06) (xy 260.35 87.63)
 		)
 		(stroke
@@ -2724,7 +2724,7 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 92.71) (xy 99.06 88.9)
+			(xy 99.06 87.63) (xy 99.06 83.82)
 		)
 		(stroke
 			(width 0)
@@ -2845,7 +2845,7 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 100.33) (xy 99.06 102.87)
+			(xy 99.06 95.25) (xy 99.06 97.79)
 		)
 		(stroke
 			(width 0)
@@ -2865,7 +2865,7 @@
 	)
 	(wire
 		(pts
-			(xy 88.9 105.41) (xy 111.76 105.41)
+			(xy 82.55 105.41) (xy 111.76 105.41)
 		)
 		(stroke
 			(width 0)
@@ -2875,7 +2875,7 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 88.9) (xy 121.92 88.9)
+			(xy 99.06 83.82) (xy 121.92 83.82)
 		)
 		(stroke
 			(width 0)
@@ -2885,7 +2885,7 @@
 	)
 	(wire
 		(pts
-			(xy 88.9 88.9) (xy 99.06 88.9)
+			(xy 82.55 83.82) (xy 99.06 83.82)
 		)
 		(stroke
 			(width 0)
@@ -2925,7 +2925,17 @@
 	)
 	(wire
 		(pts
-			(xy 88.9 100.33) (xy 88.9 105.41)
+			(xy 91.44 95.25) (xy 91.44 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "934ed371-de22-46a5-9879-3f8d8ef83bc2")
+	)
+	(wire
+		(pts
+			(xy 82.55 95.25) (xy 82.55 105.41)
 		)
 		(stroke
 			(width 0)
@@ -2935,23 +2945,33 @@
 	)
 	(wire
 		(pts
-			(xy 121.92 88.9) (xy 121.92 90.17)
+			(xy 91.44 102.87) (xy 111.76 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "982eba96-d6a8-44a1-b908-eb5848933de9")
+		(uuid "9602610e-77c0-4121-a432-f57fe2708ea4")
 	)
 	(wire
 		(pts
-			(xy 88.9 92.71) (xy 88.9 88.9)
+			(xy 82.55 87.63) (xy 82.55 83.82)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "99d53ab9-165d-453a-9fe3-557a49b9a5d2")
+	)
+	(wire
+		(pts
+			(xy 121.92 80.01) (xy 121.92 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a5e7146-d5e4-4809-9bf0-820a63a3baf9")
 	)
 	(wire
 		(pts
@@ -3057,7 +3077,7 @@
 	)
 	(wire
 		(pts
-			(xy 78.74 88.9) (xy 88.9 88.9)
+			(xy 72.39 83.82) (xy 82.55 83.82)
 		)
 		(stroke
 			(width 0)
@@ -3087,13 +3107,23 @@
 	)
 	(wire
 		(pts
-			(xy 78.74 97.79) (xy 78.74 101.6)
+			(xy 72.39 92.71) (xy 72.39 96.52)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "b5cc32af-a248-4a71-9424-c239f9d74dee")
+	)
+	(wire
+		(pts
+			(xy 91.44 87.63) (xy 91.44 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba2ff93e-4e0b-4c0c-ab77-547d8329d840")
 	)
 	(wire
 		(pts
@@ -3107,16 +3137,6 @@
 	)
 	(wire
 		(pts
-			(xy 111.76 97.79) (xy 109.22 97.79)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "c36f7079-a126-4e6d-9925-6b0d4c9305cb")
-	)
-	(wire
-		(pts
 			(xy 187.96 99.06) (xy 187.96 104.14)
 		)
 		(stroke
@@ -3127,7 +3147,7 @@
 	)
 	(wire
 		(pts
-			(xy 78.74 88.9) (xy 78.74 92.71)
+			(xy 72.39 83.82) (xy 72.39 87.63)
 		)
 		(stroke
 			(width 0)
@@ -3185,6 +3205,16 @@
 		)
 		(uuid "dfb4d39e-5bf6-4bf0-9298-e9045263a6aa")
 	)
+	(wire
+		(pts
+			(xy 121.92 83.82) (xy 121.92 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e26bfef2-b208-4373-a049-9ba8ded666ea")
+	)
 	(polyline
 		(pts
 			(xy 284.48 60.96) (xy 245.11 60.96)
@@ -3205,16 +3235,6 @@
 			(type default)
 		)
 		(uuid "e972dc33-1136-48b9-95d0-b5b3adc3896f")
-	)
-	(wire
-		(pts
-			(xy 109.22 102.87) (xy 111.76 102.87)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ea71cf24-55dc-45c8-9041-cc4d4f47fc99")
 	)
 	(wire
 		(pts
@@ -3239,16 +3259,6 @@
 	)
 	(wire
 		(pts
-			(xy 121.92 85.09) (xy 121.92 88.9)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f98cee07-3937-49fe-8032-9771f34a98e9")
-	)
-	(wire
-		(pts
 			(xy 187.96 109.22) (xy 187.96 113.03)
 		)
 		(stroke
@@ -3267,19 +3277,9 @@
 		)
 		(uuid "fdf7187e-75c8-49d7-984f-9eb86611c2b2")
 	)
-	(wire
-		(pts
-			(xy 109.22 97.79) (xy 109.22 102.87)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "fe7b446f-bbfd-41f0-9fa1-ace43190ea9c")
-	)
 	(symbol
 		(lib_id "Device:C_Small")
-		(at 78.74 95.25 0)
+		(at 72.39 90.17 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -3289,7 +3289,7 @@
 		(dnp no)
 		(uuid "02ea4f82-98aa-40f6-b9e3-fc688e24e091")
 		(property "Reference" "C8"
-			(at 80.01 92.71 0)
+			(at 73.66 87.63 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -3300,7 +3300,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 80.01 97.79 0)
+			(at 73.66 92.71 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -3311,7 +3311,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 78.74 95.25 0)
+			(at 72.39 90.17 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3322,7 +3322,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 78.74 95.25 0)
+			(at 72.39 90.17 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3333,7 +3333,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor, small symbol"
-			(at 78.74 95.25 0)
+			(at 72.39 90.17 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -3456,6 +3456,87 @@
 			(project "HW"
 				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
 					(reference "U3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 91.44 91.44 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "0d332864-6e5a-4622-b73d-f704b848c717")
+		(property "Reference" "R11"
+			(at 92.71 89.662 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1K"
+			(at 92.71 93.218 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 89.662 91.44 90)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 91.44 91.44 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 91.44 91.44 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "1c139043-69b5-4b46-89f2-877527626441")
+		)
+		(pin "1"
+			(uuid "5e4d5ffb-895a-4f27-9df9-ff80beba6bfb")
+		)
+		(instances
+			(project "HW"
+				(path "/01550cd7-b424-469c-925b-c370f3609cd4/360b299b-84d8-4d26-8110-4c6e53cc9fa4"
+					(reference "R11")
 					(unit 1)
 				)
 			)
@@ -4340,7 +4421,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 78.74 101.6 0)
+		(at 72.39 96.52 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -4351,7 +4432,7 @@
 		(fields_autoplaced yes)
 		(uuid "51cf57c3-01e3-4d89-ae3b-b777c14de87f")
 		(property "Reference" "#PWR029"
-			(at 78.74 107.95 0)
+			(at 72.39 102.87 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4362,7 +4443,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 78.74 106.68 0)
+			(at 72.39 101.6 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -4372,7 +4453,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 78.74 101.6 0)
+			(at 72.39 96.52 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4383,7 +4464,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 78.74 101.6 0)
+			(at 72.39 96.52 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4394,7 +4475,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 78.74 101.6 0)
+			(at 72.39 96.52 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4578,7 +4659,7 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 99.06 96.52 0)
+		(at 99.06 91.44 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -4586,10 +4667,9 @@
 		(on_board yes)
 		(in_pos_files yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "76cc41e0-4878-4f99-8943-41c51d758991")
 		(property "Reference" "R4"
-			(at 101.6 95.2499 0)
+			(at 100.076 89.662 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -4600,7 +4680,7 @@
 			)
 		)
 		(property "Value" "1K"
-			(at 101.6 97.7899 0)
+			(at 100.076 93.472 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -4611,7 +4691,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 97.282 96.52 90)
+			(at 97.282 91.44 90)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4622,7 +4702,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 99.06 96.52 0)
+			(at 99.06 91.44 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -4633,7 +4713,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 99.06 96.52 0)
+			(at 99.06 91.44 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -5778,7 +5858,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 121.92 85.09 0)
+		(at 121.92 80.01 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -5789,7 +5869,7 @@
 		(fields_autoplaced yes)
 		(uuid "bd7d220c-ee07-4791-b227-471b85b009b7")
 		(property "Reference" "#PWR031"
-			(at 121.92 88.9 0)
+			(at 121.92 83.82 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -5800,7 +5880,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 121.92 80.01 0)
+			(at 121.92 74.93 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -5810,7 +5890,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 121.92 85.09 0)
+			(at 121.92 80.01 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -5821,7 +5901,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 121.92 85.09 0)
+			(at 121.92 80.01 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -5832,7 +5912,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 121.92 85.09 0)
+			(at 121.92 80.01 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6178,7 +6258,7 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 88.9 96.52 0)
+		(at 82.55 91.44 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -6186,10 +6266,9 @@
 		(on_board yes)
 		(in_pos_files yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "ce86efd4-61c9-438e-af01-254e392fd208")
 		(property "Reference" "R3"
-			(at 91.44 95.2499 0)
+			(at 83.82 89.662 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -6200,7 +6279,7 @@
 			)
 		)
 		(property "Value" "1K"
-			(at 91.44 97.7899 0)
+			(at 83.82 93.218 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -6211,7 +6290,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 87.122 96.52 90)
+			(at 80.772 91.44 90)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6222,7 +6301,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 88.9 96.52 0)
+			(at 82.55 91.44 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6233,7 +6312,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 88.9 96.52 0)
+			(at 82.55 91.44 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)


### PR DESCRIPTION
## What this fixes

Follow-up to the merged USB fix. Six remaining defects that
would have prevented the board from working: the charger chip's
status pin shorted to its enable pin, no clock crystal on the
USB-UART chip, analog ground with no return path, no MCU
programming connector, wrong footprint on J1, and a floating
temperature pin on the charger. All six are fixed.

## Technical detail

Branch `fix/p0-critical-fixes` based on `master` (`50b7747`,
which already contains the USB D+/D- fix). 6 commits:

- `e5844fc` — J1 footprint corrected to 1x03 (matches symbol)
- `194c299` — CE separated from CHRG (was merged net)
- `ce28d2e` — Y1 12MHz crystal + C13/C14 27pF on U5 OSCI/OSCO
- `02632e7` — GNDA tied to GND via R12 0R star point
- `400e2a6` — J4 1x04 SWD header (+3V3/SWCLK/SWDIO/GND)
- `281c0db` — U3 TEMP tied to GND (no-NTC config)

Each fix verified by re-exporting the sheet and confirming net
topology before committing.

## Follow-ups (not in this PR)

- LoRa DIO0/DIO1 wiring, U3 EPAD copper, USB ESD, +VSYS bulk
  cap, Rprog sizing, test points, reset pull-up